### PR TITLE
Change to SearchForOrganizations

### DIFF
--- a/ZendeskApi_v2/Requests/Organizations.cs
+++ b/ZendeskApi_v2/Requests/Organizations.cs
@@ -30,7 +30,7 @@ namespace ZendeskApi_v2.Requests
 
         public GroupOrganizationResponse SearchForOrganizations(string searchTerm)
         {
-            return GenericPost<GroupOrganizationResponse>(string.Format("organizations/autocomplete.json?external_id={0}", searchTerm));
+            return GenericGet<GroupOrganizationResponse>(string.Format("organizations/search.json?external_id={0}", searchTerm));
         }
 
         public IndividualOrganizationResponse GetOrganization(long id)


### PR DESCRIPTION
I've changed the request when searching for organizations to use a search by external id instead of a "starting with"-search to align with Zendesk API documentation.
