### PR TITLE
Added support to get tickets by organization ID

### DIFF
--- a/Tests/TicketTests.cs
+++ b/Tests/TicketTests.cs
@@ -27,6 +27,14 @@ namespace Tests
         }
 
         [Test]
+        public void CanCanGetTicketsByOrganizationIDAsync()
+        {
+            var id = Settings.OrganizationId;
+            var tickets = api.Tickets.GetTicketsByOrganizationIDAsync(id);
+            Assert.True(tickets.Result.Count > 0);
+        }
+
+        [Test]
         public void CanCreateUpdateAndDeleteTicketAsync()
         {            
             var ticket = new Ticket()
@@ -77,6 +85,14 @@ namespace Tests
             var ticket = api.Tickets.GetTicket(id).Ticket;
             Assert.NotNull(ticket);
             Assert.AreEqual(ticket.Id, id);
+        }
+
+        [Test]
+        public void CanGetTicketsByOrganizationId()
+        {
+            var id = Settings.OrganizationId;
+            var tickets = api.Tickets.GetTicketsByOrganizationID(id);
+            Assert.True(tickets.Count > 0);
         }
         
         [Test]

--- a/ZendeskApi_v2/Requests/Tickets.cs
+++ b/ZendeskApi_v2/Requests/Tickets.cs
@@ -16,6 +16,7 @@ namespace ZendeskApi_v2.Requests
     {
         private const string _tickets = "tickets";
         private const string _views = "views";
+        private const string _organizations = "organizations";
 
 
         public Tickets(string yourZendeskUrl, string user, string password)
@@ -32,6 +33,11 @@ namespace ZendeskApi_v2.Requests
         public GroupTicketResponse GetTicketsByViewID(int id)
         {
             return GenericGet<GroupTicketResponse>(string.Format("{0}/{1}/{2}.json", _views, id, _tickets));
+        }
+
+        public GroupTicketResponse GetTicketsByOrganizationID(long id)
+        {
+            return GenericGet<GroupTicketResponse>(string.Format("{0}/{1}/{2}.json", _organizations, id, _tickets));
         }
 
         public IndividualTicketResponse GetTicket(long id)
@@ -208,6 +214,11 @@ namespace ZendeskApi_v2.Requests
         public async Task<GroupTicketResponse> GetTicketsByViewIDAsync(int id)
         {
             return await GenericGetAsync<GroupTicketResponse>(string.Format("{0}/{1}/{2}.json", _views, id, _tickets));
+        }
+
+        public async Task<GroupTicketResponse> GetTicketsByOrganizationIDAsync(long id)
+        {
+            return await GenericGetAsync<GroupTicketResponse>(string.Format("{0}/{1}/{2}.json", _organizations, id, _tickets));
         }
 
         public async Task<IndividualTicketResponse> GetTicketAsync(long id)


### PR DESCRIPTION
Followed the pattern of previous pull requests - a very simple addition to the API.  Added sync and async support as well as tests for both.
