### PR TITLE
Change type of date/time fields from 'string' to 'DateTimeOffset'

### DIFF
--- a/ZendeskApi_v2/Models/AccountsAndActivities/Activity.cs
+++ b/ZendeskApi_v2/Models/AccountsAndActivities/Activity.cs
@@ -1,7 +1,9 @@
 ﻿// JSON C# Class Generator
 // http://at-my-window.blogspot.com/?page=json-class-generator
 
+using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 
 namespace ZendeskApi_v2.Models.AccountsAndActivities
@@ -29,9 +31,11 @@ namespace ZendeskApi_v2.Models.AccountsAndActivities
         public ZendeskApi_v2.Models.Users.User Actor { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Categories/Category.cs
+++ b/ZendeskApi_v2/Models/Categories/Category.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Categories
@@ -24,9 +25,11 @@ namespace ZendeskApi_v2.Models.Categories
         public int Position { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/CustomRoles/CustomRole.cs
+++ b/ZendeskApi_v2/Models/CustomRoles/CustomRole.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.CustomRoles
@@ -21,10 +22,12 @@ namespace ZendeskApi_v2.Models.CustomRoles
         public string Description { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("configuration")]
         public Configuration Configuration { get; set; }

--- a/ZendeskApi_v2/Models/Forums/Forum.cs
+++ b/ZendeskApi_v2/Models/Forums/Forum.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Forums
@@ -43,9 +44,11 @@ namespace ZendeskApi_v2.Models.Forums
         public string Access { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Forums/ForumSubscription.cs
+++ b/ZendeskApi_v2/Models/Forums/ForumSubscription.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Forums
@@ -22,6 +23,7 @@ namespace ZendeskApi_v2.Models.Forums
         public long? UserId { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Groups/Group.cs
+++ b/ZendeskApi_v2/Models/Groups/Group.cs
@@ -1,4 +1,6 @@
+using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Groups
 {
@@ -18,9 +20,11 @@ namespace ZendeskApi_v2.Models.Groups
         public bool Deleted { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Groups/GroupMembership.cs
+++ b/ZendeskApi_v2/Models/Groups/GroupMembership.cs
@@ -1,4 +1,6 @@
+using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Groups
 {
@@ -21,9 +23,11 @@ namespace ZendeskApi_v2.Models.Groups
         public bool Default { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Locales/Locale.cs
+++ b/ZendeskApi_v2/Models/Locales/Locale.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Locales
@@ -25,9 +26,11 @@ namespace ZendeskApi_v2.Models.Locales
         public string Name { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Macros/Macro.cs
+++ b/ZendeskApi_v2/Models/Macros/Macro.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Macros
@@ -24,10 +25,12 @@ namespace ZendeskApi_v2.Models.Macros
         public bool? Active { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("restriction")]
         public Restriction Restriction { get; set; }

--- a/ZendeskApi_v2/Models/Organizations/Organization.cs
+++ b/ZendeskApi_v2/Models/Organizations/Organization.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Organizations
@@ -25,10 +26,12 @@ namespace ZendeskApi_v2.Models.Organizations
         public string Name { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("domain_names")]
         public IList<object> DomainNames { get; set; }

--- a/ZendeskApi_v2/Models/Requests/Request.cs
+++ b/ZendeskApi_v2/Models/Requests/Request.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using ZendeskApi_v2.Models.Shared;
 using ZendeskApi_v2.Models.Tickets;
@@ -39,10 +40,12 @@ namespace ZendeskApi_v2.Models.Requests
         public IList<CustomField> CustomFields { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         /// <summary>
         /// This is used for updates only

--- a/ZendeskApi_v2/Models/SatisfactionRatings/SatisfactionRating.cs
+++ b/ZendeskApi_v2/Models/SatisfactionRatings/SatisfactionRating.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Satisfaction
@@ -34,10 +35,12 @@ namespace ZendeskApi_v2.Models.Satisfaction
         public string Score { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("comment")]
         public string Comment { get; set; }

--- a/ZendeskApi_v2/Models/Search/Result.cs
+++ b/ZendeskApi_v2/Models/Search/Result.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using ZendeskApi_v2.Models.Shared;
 using ZendeskApi_v2.Models.Tickets;
@@ -66,10 +67,12 @@ namespace ZendeskApi_v2.Models.Search
         public int? CommentsCount { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("id")]
         public int Id { get; set; }

--- a/ZendeskApi_v2/Models/Shared/Audit.cs
+++ b/ZendeskApi_v2/Models/Shared/Audit.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Shared
 {
@@ -12,7 +14,8 @@ namespace ZendeskApi_v2.Models.Shared
         public string TicketId { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("author_id")]
         public long AuthorId { get; set; }

--- a/ZendeskApi_v2/Models/SharingAgreements/SharingAgreement.cs
+++ b/ZendeskApi_v2/Models/SharingAgreements/SharingAgreement.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.SharingAgreements
@@ -27,6 +28,7 @@ namespace ZendeskApi_v2.Models.SharingAgreements
         public string Status { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Tickets/BaseTicket.cs
+++ b/ZendeskApi_v2/Models/Tickets/BaseTicket.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Tickets
 {
@@ -11,10 +13,12 @@ namespace ZendeskApi_v2.Models.Tickets
         public long? Id { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
     }
 }

--- a/ZendeskApi_v2/Models/Tickets/Comment.cs
+++ b/ZendeskApi_v2/Models/Tickets/Comment.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using ZendeskApi_v2.Models.Shared;
 
 namespace ZendeskApi_v2.Models.Tickets
@@ -43,7 +45,8 @@ namespace ZendeskApi_v2.Models.Tickets
         public MetaData MetaData { get; private set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
     }
 

--- a/ZendeskApi_v2/Models/Tickets/FieldHeaders.cs
+++ b/ZendeskApi_v2/Models/Tickets/FieldHeaders.cs
@@ -1,4 +1,6 @@
+using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Tickets
 {
@@ -42,25 +44,31 @@ namespace ZendeskApi_v2.Models.Tickets
         public string TicketType { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("assigned_at")]
-        public string AssignedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? AssignedAt { get; set; }
 
         [JsonProperty("organization_name")]
         public string OrganizationName { get; set; }
 
         [JsonProperty("due_date")]
-        public string DueDate { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? DueDate { get; set; }
 
         [JsonProperty("initially_assigned_at")]
-        public string InitiallyAssignedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? InitiallyAssignedAt { get; set; }
 
         [JsonProperty("solved_at")]
-        public string SolvedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? SolvedAt { get; set; }
 
         [JsonProperty("resolution_time")]
         public string ResolutionTime { get; set; }

--- a/ZendeskApi_v2/Models/Tickets/Suspended/SuspendedTicket.cs
+++ b/ZendeskApi_v2/Models/Tickets/Suspended/SuspendedTicket.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Tickets.Suspended
@@ -34,10 +35,12 @@ namespace ZendeskApi_v2.Models.Tickets.Suspended
         public string MessageId { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("via")]
         public Via Via { get; set; }

--- a/ZendeskApi_v2/Models/Tickets/Ticket.cs
+++ b/ZendeskApi_v2/Models/Tickets/Ticket.cs
@@ -1,13 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using ZendeskApi_v2.Models.Shared;
 
 namespace ZendeskApi_v2.Models.Tickets
 {    
     public class Ticket : BaseTicket
     {
-        
-
         [JsonProperty("external_id")]
         public object ExternalId { get; set; }             
 
@@ -70,7 +70,8 @@ namespace ZendeskApi_v2.Models.Tickets
         public bool? HasIncidents { get; set; }
 
         [JsonProperty("due_at")]
-        public string? DueAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? DueAt { get; set; }
 
         [JsonProperty("tags")]
         public IList<string> Tags { get; set; }

--- a/ZendeskApi_v2/Models/Tickets/TicketExportResult.cs
+++ b/ZendeskApi_v2/Models/Tickets/TicketExportResult.cs
@@ -1,4 +1,6 @@
+using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Tickets
 {
@@ -51,13 +53,16 @@ namespace ZendeskApi_v2.Models.Tickets
         public string TicketType { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("assigned_at")]
-        public string AssignedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? AssignedAt { get; set; }
 
         [JsonProperty("organization_name")]
         public string OrganizationName { get; set; }
@@ -66,10 +71,12 @@ namespace ZendeskApi_v2.Models.Tickets
         public object DueDate { get; set; }
 
         [JsonProperty("initially_assigned_at")]
-        public string InitiallyAssignedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? InitiallyAssignedAt { get; set; }
 
         [JsonProperty("solved_at")]
-        public string SolvedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? SolvedAt { get; set; }
 
         [JsonProperty("resolution_time")]
         public string ResolutionTime { get; set; }

--- a/ZendeskApi_v2/Models/Tickets/TicketField.cs
+++ b/ZendeskApi_v2/Models/Tickets/TicketField.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Tickets
 {
@@ -62,10 +64,12 @@ namespace ZendeskApi_v2.Models.Tickets
         public string Url { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
 
     public  class CustomFieldOptions

--- a/ZendeskApi_v2/Models/Tickets/TicketForm.cs
+++ b/ZendeskApi_v2/Models/Tickets/TicketForm.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Tickets
 {
@@ -34,9 +36,11 @@ namespace ZendeskApi_v2.Models.Tickets
         public bool Default { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Tickets/TicketMetric.cs
+++ b/ZendeskApi_v2/Models/Tickets/TicketMetric.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Tickets
 {
@@ -20,25 +22,32 @@ namespace ZendeskApi_v2.Models.Tickets
         public long? Replies { get; set; }
 
         [JsonProperty("assignee_updated_at")]
-        public string AssigneeUpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? AssigneeUpdatedAt { get; set; }
 
         [JsonProperty("requester_updated_at")]
-        public string RequesterUpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? RequesterUpdatedAt { get; set; }
 
         [JsonProperty("status_updated_at")]
-        public string StatusUpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? StatusUpdatedAt { get; set; }
 
         [JsonProperty("initially_assigned_at")]
-        public string InitiallyAssignedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? InitiallyAssignedAt { get; set; }
 
         [JsonProperty("assigned_at")]
-        public string AssignedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? AssignedAt { get; set; }
 
         [JsonProperty("solved_at")]
-        public string SolvedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? SolvedAt { get; set; }
 
         [JsonProperty("latest_comment_added_at")]
-        public string LatestCommentAddedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? LatestCommentAddedAt { get; set; }
 
         [JsonProperty("first_resolution_time_in_minutes")]
         public TimeSpanMetric FirstResolutionTimeInMinutes { get; set; }

--- a/ZendeskApi_v2/Models/Topics/Topic.cs
+++ b/ZendeskApi_v2/Models/Topics/Topic.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using ZendeskApi_v2.Models.Shared;
 
@@ -60,10 +61,12 @@ namespace ZendeskApi_v2.Models.Topics
         public int CommentsCount { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
         
         /// <summary>
         /// Used for uploading Topics only

--- a/ZendeskApi_v2/Models/Topics/TopicComment.cs
+++ b/ZendeskApi_v2/Models/Topics/TopicComment.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using ZendeskApi_v2.Models.Shared;
 
@@ -32,10 +33,12 @@ namespace ZendeskApi_v2.Models.Topics
         public IList<Attachment> Attachments { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
         
         /// <summary>
         /// Used for uploading attachments only

--- a/ZendeskApi_v2/Models/Topics/TopicSubscription.cs
+++ b/ZendeskApi_v2/Models/Topics/TopicSubscription.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Topics
@@ -21,6 +22,7 @@ namespace ZendeskApi_v2.Models.Topics
         public long UserId { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Topics/TopicVote.cs
+++ b/ZendeskApi_v2/Models/Topics/TopicVote.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Topics
@@ -21,6 +22,7 @@ namespace ZendeskApi_v2.Models.Topics
         public long TopicId { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Triggers/Trigger.cs
+++ b/ZendeskApi_v2/Models/Triggers/Trigger.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Triggers
@@ -25,10 +26,12 @@ namespace ZendeskApi_v2.Models.Triggers
         public bool Active { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("actions")]
         public IList<Action> Actions { get; set; }

--- a/ZendeskApi_v2/Models/Users/User.cs
+++ b/ZendeskApi_v2/Models/Users/User.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Users
 {
@@ -24,10 +25,12 @@ namespace ZendeskApi_v2.Models.Users
         public string Alias { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+		[JsonConverter(typeof(IsoDateTimeConverter))]
+                public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+		[JsonConverter(typeof(IsoDateTimeConverter))]
+                public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("active")]
         public bool? Active { get; set; }
@@ -45,7 +48,8 @@ namespace ZendeskApi_v2.Models.Users
         public string TimeZone { get; set; }
 
         [JsonProperty("last_login_at")]
-        public string LastLoginAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? LastLoginAt { get; set; }
 
         [JsonProperty("email")]
         public string Email { get; set; }

--- a/ZendeskApi_v2/Models/Users/UserIdentity.cs
+++ b/ZendeskApi_v2/Models/Users/UserIdentity.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace ZendeskApi_v2.Models.Users
@@ -31,9 +32,11 @@ namespace ZendeskApi_v2.Models.Users
         public bool Primary { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Views/Executed/LastComment.cs
+++ b/ZendeskApi_v2/Models/Views/Executed/LastComment.cs
@@ -1,7 +1,9 @@
 ﻿// JSON C# Class Generator
 // http://at-my-window.blogspot.com/?page=json-class-generator
 
+using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Views.Executed
 {
@@ -13,7 +15,8 @@ namespace ZendeskApi_v2.Models.Views.Executed
         public string Body { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("author_id")]
         public long AuthorId { get; set; }

--- a/ZendeskApi_v2/Models/Views/View.cs
+++ b/ZendeskApi_v2/Models/Views/View.cs
@@ -1,7 +1,9 @@
 ﻿// JSON C# Class Generator
 // http://at-my-window.blogspot.com/?page=json-class-generator
 
+using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace ZendeskApi_v2.Models.Views
 {
@@ -22,10 +24,12 @@ namespace ZendeskApi_v2.Models.Views
         public bool Active { get; set; }
 
         [JsonProperty("updated_at")]
-        public string UpdatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("created_at")]
-        public string CreatedAt { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
 
         [JsonProperty("restriction")]
         public object Restriction { get; set; }


### PR DESCRIPTION
Hi, this is my first PR to your repo, let me know if there are things you'd like done differently.

The Zendesk API v2 requires that most date/times be formatted as ISO8601. In the ZendeskApi_v2 library, the types of date/time fields is always `string`.

It would be helpful for it to be `DateTime` or `DateTimeOffset` so that developers don't pass incorrect date/time formats to the Zendesk API. For instance, there have been Zendesk API developers who have passed strings like `Friday, September 9, 2014 8:03 AM` for `due_at` to the Zendesk API.

It also is helpful for developers when receiving values back from the Zendesk API; if they're already of type `DateTime` or `DateTimeOffset` in the returned result, the developer doesn't have to worry about parsing the result.

I chose `DateTimeOffset` over `DateTime` since it includes timezone information and is the more modern choice in the .NET Framework. (Does this make sense?)

This is probably a breaking change so I suppose it'll have to be carefully considered. However, I think most developers would prefer to work with a real date/time object instead of a string in this case.
- Changed date/time types from `string` to `DateTimeOffset?`
- Added unit test for creating a ticket with `DueAt` setting
- Add check for `CreatedAt`, `UpdatedAt` to ticket creation test
