### PR TITLE
Add CustomFieldOptions.Id property

### DIFF
--- a/ZendeskApi_v2/Models/Tickets/TicketField.cs
+++ b/ZendeskApi_v2/Models/Tickets/TicketField.cs
@@ -70,6 +70,9 @@ namespace ZendeskApi_v2.Models.Tickets
 
     public  class CustomFieldOptions
     {
+        [JsonProperty("id")]
+        public long? Id{ get; set; }
+
         [JsonProperty("name")]
         public string Name { get; set; }
 


### PR DESCRIPTION
Dear Eric,
This is my first 'pull request' in GitHub ever, so this might not be the good way to proceed.
Feel free to let me know.

I would like to suggest this patch, which adds an 'id' field in the CustomFieldOptions.
This would allows updating the CustomFieldOptions of a TicketField.
I have included a UnitTest to demonstrate the use case which would be covered.

Regards,
Gilles
