### PR TITLE
- ADD. OAuth2 access token using in request headers.

### DIFF
--- a/ZendeskApi_v2/Core.cs
+++ b/ZendeskApi_v2/Core.cs
@@ -233,9 +233,19 @@ namespace ZendeskApi_v2
         protected string GetPasswordOrTokenAuthHeader()
         {
             if (!String.IsNullOrEmpty(ApiToken) && ApiToken.Trim().Length >= 0)
-                return GetAuthHeader(User + "/token", ApiToken);
-            
+            {
+                if (!String.IsNullOrEmpty(User) && User.Trim().Length >= 0)
+                    return GetAuthHeader(User + "/token", ApiToken);
+
+                return GetAuthBearerHeader(ApiToken);
+            }
+
             return GetAuthHeader(User, Password);
+        }
+
+        protected string GetAuthBearerHeader(string accessToken)
+        {
+            return string.Format("Bearer {0}", accessToken);
         }
 
         protected string GetAuthHeader(string userName, string password)

--- a/ZendeskApi_v2/ZendeskApi.cs
+++ b/ZendeskApi_v2/ZendeskApi.cs
@@ -71,7 +71,7 @@ namespace ZendeskApi_v2
         /// <param name="password">LEAVE BLANK IF USING TOKEN</param>
         /// <param name="apiToken">Optional Param which is used if specified instead of the password</param>
         /// <param name="locale">Optional param which designates the locale to use for Help Center requests. Defaults to "en-us" if no value is provided.</param>
-        public ZendeskApi(string yourZendeskUrl, string user, string password="", string apiToken="", string locale="en-us")
+        public ZendeskApi(string yourZendeskUrl, string user="", string password="", string apiToken="", string locale="en-us")
         {
             var formattedUrl = GetFormattedZendeskUrl(yourZendeskUrl).AbsoluteUri;
             


### PR DESCRIPTION
Added possibility to use OAuth access token in request header.
In that case leave "user" and "password" parameters blank and pass access token as apiToken parameter.

PS. Tried to implement it with as little changes as possible.