### PR TITLE
Implement side-loading objects in IndividualTicketResponse.

### DIFF
--- a/Tests/TicketTests.cs
+++ b/Tests/TicketTests.cs
@@ -21,12 +21,22 @@ namespace Tests
     public class TicketTests
     {
         ZendeskApi api = new ZendeskApi(Settings.Site, Settings.Email, Settings.Password);
+        TicketSideLoadOptionsEnum ticketSideLoadOptions = TicketSideLoadOptionsEnum.Users | TicketSideLoadOptionsEnum.Organizations | TicketSideLoadOptionsEnum.Groups;
 
         [Test]
         public void CanGetTicketsAsync()
         {
             var tickets = api.Tickets.GetAllTicketsAsync();
             Assert.True(tickets.Result.Count > 0);
+        }
+
+        [Test]
+        public void CanGetTicketsAsyncWithSideLoad()
+        {
+            var tickets = api.Tickets.GetAllTicketsAsync(sideLoadOptions: ticketSideLoadOptions);
+            Assert.True(tickets.Result.Count > 0);
+            Assert.IsTrue(tickets.Result.Users.Any());
+            Assert.IsTrue(tickets.Result.Organizations.Any());
         }
 
         [Test]
@@ -89,6 +99,15 @@ namespace Tests
         }
 
         [Test]
+        public void CanGetTicketsWithSideLoad()
+        {
+            var tickets = api.Tickets.GetAllTickets(sideLoadOptions: ticketSideLoadOptions);
+            Assert.True(tickets.Count > 0);
+            Assert.IsTrue(tickets.Users.Any());
+            Assert.IsTrue(tickets.Organizations.Any());
+        }
+
+        [Test]
         public void CanGetTicketsPaged()
         {
             const int count = 50;
@@ -120,6 +139,18 @@ namespace Tests
             var ticket = api.Tickets.GetTicket(id).Ticket;
             Assert.NotNull(ticket);
             Assert.AreEqual(ticket.Id, id);
+        }
+
+        [Test]
+        public void CanGetTicketByIdWithSideLoad()
+        {
+            var id = Settings.SampleTicketId;
+            var ticket = api.Tickets.GetTicket(id, sideLoadOptions: ticketSideLoadOptions);
+            Assert.NotNull(ticket);
+            Assert.NotNull(ticket.Ticket);
+            Assert.AreEqual(ticket.Ticket.Id, id);
+            Assert.IsTrue(ticket.Users.Any());
+            Assert.IsTrue(ticket.Organizations.Any());
         }
 
         [Test]
@@ -171,6 +202,16 @@ namespace Tests
         }
 
         [Test]
+        public void CanGetTicketsByViewIdPagedWithSideLoad()
+        {
+            CanGetTicketsByViewIdPaged();
+            var ticketsRes = api.Tickets.GetTicketsByViewID(Settings.ViewId, 10, 2, sideLoadOptions: ticketSideLoadOptions);
+
+            Assert.IsTrue(ticketsRes.Users.Any());
+            Assert.IsTrue(ticketsRes.Users.Any());
+        }
+
+        [Test]
         [Ignore("fragile needs to be changed.")]
         public void CanGetRecentTicketsPaged()
         {
@@ -209,9 +250,23 @@ namespace Tests
             Assert.AreEqual("3", nextPage);
         }
 
+        [Test]
+        public void CanTicketsByUserIdPagedWithSideLoad()
+        {
+            CanTicketsByUserIdPaged();
+            var ticketsRes = api.Tickets.GetTicketsByUserID(Settings.UserId, 5, 2, sideLoadOptions: ticketSideLoadOptions);
+            Assert.IsTrue(ticketsRes.Users.Any());
+            Assert.IsTrue(ticketsRes.Organizations.Any());
+        }
 
-
-
+        [Test]
+        public void CanTicketsByUserIdPagedAsyncWithSideLoad()
+        {
+            var ticketsRes = api.Tickets.GetTicketsByUserIDAsync(Settings.UserId, 5, 2, sideLoadOptions: ticketSideLoadOptions);
+            Assert.IsTrue(ticketsRes.Result.Users.Any());
+            Assert.IsTrue(ticketsRes.Result.Organizations.Any());
+        }
+        
         [Test]
         public void CanGetMultipleTickets()
         {
@@ -229,6 +284,29 @@ namespace Tests
             Assert.NotNull(tickets);
             Assert.AreEqual(tickets.Count, ids.Count);
         }
+
+        [Test]
+        public void CanGetMultipleTicketsWithSideLoad()
+        {
+            var ids = new List<long>() { Settings.SampleTicketId, Settings.SampleTicketId2 };
+            var tickets = api.Tickets.GetMultipleTickets(ids, sideLoadOptions: ticketSideLoadOptions);
+            Assert.NotNull(tickets);
+            Assert.AreEqual(tickets.Count, ids.Count);
+            Assert.IsTrue(tickets.Users.Any());
+            Assert.IsTrue(tickets.Organizations.Any());
+        }
+
+        [Test]
+        public async Task CanGetMultipleTicketsAsyncWithSideLoad()
+        {
+            var ids = new List<long>() { Settings.SampleTicketId, Settings.SampleTicketId2 };
+            var tickets = await api.Tickets.GetMultipleTicketsAsync(ids, sideLoadOptions: ticketSideLoadOptions);
+            Assert.NotNull(tickets);
+            Assert.AreEqual(tickets.Count, ids.Count);
+            Assert.IsTrue(tickets.Users.Any());
+            Assert.IsTrue(tickets.Organizations.Any());
+        }
+
 
         [Test]
         public void CanGetMultipleTicketsSingleTicket()
@@ -835,14 +913,41 @@ namespace Tests
         }
 
         [Test]
-        public void TicketSideLoadingTest()
+        public void CanGetAllTicketsWithSideLoad()
         {
             var tickets =
-                api.Tickets.GetAllTickets(sideLoadOptions:
-                    TicketSideLoadOptionsEnum.Users |
-                    TicketSideLoadOptionsEnum.Organizations |
-                    TicketSideLoadOptionsEnum.Groups);
+                api.Tickets.GetAllTickets(sideLoadOptions: ticketSideLoadOptions);
 
+            Assert.IsTrue(tickets.Users.Any());
+            Assert.IsTrue(tickets.Organizations.Any());
+        }
+
+        [Test]
+        public void CanGetAllTicketsAsyncWithSideLoad()
+        {
+            var tickets =
+                api.Tickets.GetAllTicketsAsync(sideLoadOptions: ticketSideLoadOptions);
+
+            Assert.IsTrue(tickets.Result.Users.Any());
+            Assert.IsTrue(tickets.Result.Organizations.Any());
+        }
+
+        [Test]
+        public void CanGetTicketsByOrganizationIDAsyncWithSideLoad()
+        {
+            var id = Settings.OrganizationId;
+            var tickets = api.Tickets.GetTicketsByOrganizationIDAsync(id, sideLoadOptions: ticketSideLoadOptions);
+            Assert.True(tickets.Result.Count > 0);
+            Assert.IsTrue(tickets.Result.Users.Any());
+            Assert.IsTrue(tickets.Result.Organizations.Any());
+        }
+
+        [Test]
+        public void CanCanGetTicketsByOrganizationIDWithSideLoad()
+        {
+            var id = Settings.OrganizationId;
+            var tickets = api.Tickets.GetTicketsByOrganizationID(id, sideLoadOptions: ticketSideLoadOptions);
+            Assert.True(tickets.Count > 0);
             Assert.IsTrue(tickets.Users.Any());
             Assert.IsTrue(tickets.Organizations.Any());
         }

--- a/ZendeskApi_v2/Models/Tickets/IndividualTicketResponse.cs
+++ b/ZendeskApi_v2/Models/Tickets/IndividualTicketResponse.cs
@@ -1,5 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using ZendeskApi_v2.Models.Groups;
+using ZendeskApi_v2.Models.Organizations;
 using ZendeskApi_v2.Models.Shared;
+using ZendeskApi_v2.Models.SharingAgreements;
+using ZendeskApi_v2.Models.Users;
 
 namespace ZendeskApi_v2.Models.Tickets
 {
@@ -10,5 +15,26 @@ namespace ZendeskApi_v2.Models.Tickets
 
         [JsonProperty("audit")]
         public Audit Audit { get; set; }
+
+        [JsonProperty("users")]
+        public IList<User> Users { get; set; }
+
+        [JsonProperty("organizations")]
+        public IList<Organization> Organizations { get; set; }
+
+        [JsonProperty("groups")]
+        public IList<Group> Groups { get; set; }
+
+        [JsonProperty("sharing_agreements")]
+        public IList<SharingAgreement> SharingAgreements { get; set; }
+
+        [JsonProperty("metric_sets")]
+        public IList<TicketMetric> MetricSets { get; set; }
+
+        [JsonProperty("last_audits")]
+        public IList<Audit> LastAudits { get; set; }
+
+        [JsonProperty("ticket_forms")]
+        public IList<TicketForm> TicketForms { get; set; }
     }
 }

--- a/ZendeskApi_v2/Requests/Tickets.cs
+++ b/ZendeskApi_v2/Requests/Tickets.cs
@@ -29,6 +29,7 @@ namespace ZendeskApi_v2.Requests
 
     public interface ITickets : ICore
     {
+        
 #if SYNC
         GroupTicketFormResponse GetTicketForms();
         IndividualTicketFormResponse CreateTicketForm(TicketForm ticketForm);
@@ -161,7 +162,6 @@ namespace ZendeskApi_v2.Requests
         private const string _organizations = "organizations";
         private const string _ticket_metrics = "ticket_metrics";
 
-
         public Tickets(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
             : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
         {
@@ -213,7 +213,6 @@ namespace ZendeskApi_v2.Requests
         public GroupTicketResponse GetAllTickets(int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
         {
             string resource = GetResourceStringWithSideLoadOptionsParam(_tickets + ".json", sideLoadOptions);
-
             return GenericPagedGet<GroupTicketResponse>(resource, perPage, page);
         }
 
@@ -226,7 +225,7 @@ namespace ZendeskApi_v2.Requests
         public GroupTicketResponse GetTicketsByOrganizationID(long id, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
         {
             string resource = GetResourceStringWithSideLoadOptionsParam(string.Format("{0}/{1}/{2}.json", _organizations, id, _tickets), sideLoadOptions);
-            return GenericGet<GroupTicketResponse>(string.Format("{0}/{1}/{2}.json", _organizations, id, _tickets));
+            return GenericGet<GroupTicketResponse>(resource);
         }
 
         public GroupTicketResponse GetTicketsByOrganizationID(long id, int pageNumber, int itemsPerPage, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
@@ -244,7 +243,7 @@ namespace ZendeskApi_v2.Requests
         public GroupTicketResponse GetTicketsByUserID(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
         {
             string resource = GetResourceStringWithSideLoadOptionsParam(string.Format("users/{0}/tickets/requested.json", userId), sideLoadOptions);
-            return GenericPagedGet<GroupTicketResponse>(string.Format("users/{0}/tickets/requested.json", userId), perPage, page);
+            return GenericPagedGet<GroupTicketResponse>(resource, perPage, page);
         }
 
         public GroupTicketResponse GetTicketsWhereUserIsCopied(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
@@ -256,7 +255,7 @@ namespace ZendeskApi_v2.Requests
         public IndividualTicketResponse GetTicket(long id, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
         {
             string resource = GetResourceStringWithSideLoadOptionsParam(string.Format("{0}/{1}.json", _tickets, id), sideLoadOptions);
-            return GenericGet<IndividualTicketResponse>(string.Format("{0}/{1}.json", _tickets, id));
+            return GenericGet<IndividualTicketResponse>(resource);
         }
 
         public GroupCommentResponse GetTicketComments(long ticketId, int? perPage = null, int? page = null)


### PR DESCRIPTION
Implement side-loading objects in IndividualTicketResponse to match GroupTicketResponse object..
Fix some GetTicket methods to actually use the new url with sideloading options.
Implement a lot more unit tests for side-loading.
Thank you.