### PR TITLE
Get Multiple Users, Side-Loading and Int-Long fixes.

### DIFF
--- a/Tests/SearchTests.cs
+++ b/Tests/SearchTests.cs
@@ -76,6 +76,7 @@ namespace Tests
         {
             var res = api.Search.SearchFor(Settings.Email);
             Assert.AreEqual(res.Results[0].ResultType, "user");
+            Assert.Greater(res.Results[0].Id, 0);
         }
 
         [Test]

--- a/Tests/TicketTests.cs
+++ b/Tests/TicketTests.cs
@@ -432,6 +432,15 @@ namespace Tests
         }
 
         [Test]
+        public void CanGetTicketCommentsWithSideLoading()
+        {
+            var comments = api.Tickets.GetTicketComments(2, sideLoadOptions: ticketSideLoadOptions);
+            Assert.IsNotEmpty(comments.Users);
+            Assert.IsNull(comments.Organizations);
+        }
+
+
+        [Test]
         public void CanGetTicketCommentsPaged()
         {
             const int perPage = 5;

--- a/Tests/UserTests.cs
+++ b/Tests/UserTests.cs
@@ -11,11 +11,13 @@ using ZendeskApi_v2.Models.Constants;
 using ZendeskApi_v2.Models.Shared;
 using ZendeskApi_v2.Models.Tickets;
 using ZendeskApi_v2.Models.Users;
+using ZendeskApi_v2.Requests;
 
 
 namespace Tests
 {
     [TestFixture]
+    [Category("Users")]
     public class UserTests
     {
         ZendeskApi api = new ZendeskApi(Settings.Site, Settings.Email, Settings.Password);
@@ -176,6 +178,78 @@ namespace Tests
 
             Assert.True(api.Users.DeleteUserIdentity(userId, identityId));
             Assert.True(api.Users.DeleteUser(userId));
+        }
+
+        [Test]
+        public void CanMergeUsers()
+        {
+            var user1 = new User();
+            user1.Name = Guid.NewGuid().ToString("N") + " " + Guid.NewGuid().ToString("N");
+            user1.Email = Guid.NewGuid().ToString("N") + "@" + Guid.NewGuid().ToString("N") + ".com";
+
+            var user2 = new User();
+            user2.Name = Guid.NewGuid().ToString("N") + " " + Guid.NewGuid().ToString("N");
+            user2.Email = Guid.NewGuid().ToString("N") + "@" + Guid.NewGuid().ToString("N") + ".com";
+
+            var resultUser1 = api.Users.CreateUser(user1);
+            var resultUser2 = api.Users.CreateUser(user2);
+
+            var mergedUser = api.Users.MergeUser(resultUser1.User.Id.Value, resultUser2.User.Id.Value);
+            Thread.Sleep(2000);
+            var mergedIdentities = api.Users.GetUserIdentities(mergedUser.User.Id.Value);
+
+            Assert.AreEqual(resultUser2.User.Id, mergedUser.User.Id);
+            Assert.IsTrue(mergedIdentities.Identities.Any(i => i.Value.ToLower() == user1.Email.ToLower()));
+            Assert.IsTrue(mergedIdentities.Identities.Any(i => i.Value.ToLower() == user2.Email.ToLower()));
+
+            api.Users.DeleteUser(resultUser1.User.Id.Value);
+            api.Users.DeleteUser(resultUser2.User.Id.Value);
+
+        }
+
+        [Test]
+        public void CanMergeUsersAsync()
+        {
+            var user1 = new User();
+            user1.Name = Guid.NewGuid().ToString("N") + " " + Guid.NewGuid().ToString("N");
+            user1.Email = Guid.NewGuid().ToString("N") + "@" + Guid.NewGuid().ToString("N") + ".com";
+
+            var user2 = new User();
+            user2.Name = Guid.NewGuid().ToString("N") + " " + Guid.NewGuid().ToString("N");
+            user2.Email = Guid.NewGuid().ToString("N") + "@" + Guid.NewGuid().ToString("N") + ".com";
+
+            var resultUser1 = api.Users.CreateUser(user1);
+            var resultUser2 = api.Users.CreateUser(user2);
+
+            var mergedUser = api.Users.MergeUserAsync(resultUser1.User.Id.Value, resultUser2.User.Id.Value).Result;
+            Thread.Sleep(2000);
+            var mergedIdentities = api.Users.GetUserIdentities(mergedUser.User.Id.Value);
+
+            Assert.AreEqual(resultUser2.User.Id, mergedUser.User.Id);
+            Assert.IsTrue(mergedIdentities.Identities.Any(i => i.Value.ToLower() == user1.Email.ToLower()));
+            Assert.IsTrue(mergedIdentities.Identities.Any(i => i.Value.ToLower() == user2.Email.ToLower()));
+
+            api.Users.DeleteUser(resultUser1.User.Id.Value);
+            api.Users.DeleteUser(resultUser2.User.Id.Value);
+        }
+
+        [Test]
+        public void CanGetMultipleUsers()
+        {
+            var userList = api.Users.GetAllUsers(10,1).Users.Select(u => u.Id.Value).ToList();
+            var result = api.Users.GetMultipleUsers(userList, UserSideLoadOptions.Organizations | UserSideLoadOptions.Identities | UserSideLoadOptions.Roles);
+
+            Assert.AreEqual(userList.Count, result.Count);
+            Assert.IsTrue((result.Organizations != null && result.Organizations.Any()) || (result.Identities != null && result.Identities.Any()));
+        }
+
+        [Test]
+        public void CanGetMultipleUsersAsync()
+        {
+            var userList = api.Users.GetAllUsersAsync(10, 1).Result.Users.Select(u => u.Id.Value).ToList();
+            var result = api.Users.GetMultipleUsers(userList, UserSideLoadOptions.Organizations | UserSideLoadOptions.Identities);
+            Assert.AreEqual(userList.Count, result.Count);
+            Assert.IsTrue((result.Organizations != null && result.Organizations.Any()) || (result.Identities != null && result.Identities.Any()));
         }
     }
 }

--- a/Tests/UserTests.cs
+++ b/Tests/UserTests.cs
@@ -181,7 +181,7 @@ namespace Tests
         }
 
         [Test]
-        public void CanMergeUsers()
+        public async void CanMergeUsers()
         {
             var user1 = new User();
             user1.Name = Guid.NewGuid().ToString("N") + " " + Guid.NewGuid().ToString("N");
@@ -195,8 +195,7 @@ namespace Tests
             var resultUser2 = api.Users.CreateUser(user2);
 
             var mergedUser = api.Users.MergeUser(resultUser1.User.Id.Value, resultUser2.User.Id.Value);
-            Thread.Sleep(2000);
-            var mergedIdentities = api.Users.GetUserIdentities(mergedUser.User.Id.Value);
+            var mergedIdentities = await api.Users.GetUserIdentitiesAsync(mergedUser.User.Id.Value);
 
             Assert.AreEqual(resultUser2.User.Id, mergedUser.User.Id);
             Assert.IsTrue(mergedIdentities.Identities.Any(i => i.Value.ToLower() == user1.Email.ToLower()));
@@ -208,7 +207,7 @@ namespace Tests
         }
 
         [Test]
-        public void CanMergeUsersAsync()
+        public async void CanMergeUsersAsync()
         {
             var user1 = new User();
             user1.Name = Guid.NewGuid().ToString("N") + " " + Guid.NewGuid().ToString("N");
@@ -221,9 +220,8 @@ namespace Tests
             var resultUser1 = api.Users.CreateUser(user1);
             var resultUser2 = api.Users.CreateUser(user2);
 
-            var mergedUser = api.Users.MergeUserAsync(resultUser1.User.Id.Value, resultUser2.User.Id.Value).Result;
-            Thread.Sleep(2000);
-            var mergedIdentities = api.Users.GetUserIdentities(mergedUser.User.Id.Value);
+            var mergedUser = await api.Users.MergeUserAsync(resultUser1.User.Id.Value, resultUser2.User.Id.Value);
+            var mergedIdentities = await api.Users.GetUserIdentitiesAsync(mergedUser.User.Id.Value);
 
             Assert.AreEqual(resultUser2.User.Id, mergedUser.User.Id);
             Assert.IsTrue(mergedIdentities.Identities.Any(i => i.Value.ToLower() == user1.Email.ToLower()));

--- a/ZendeskApi_v2/Extensions/RequestExtensions.cs
+++ b/ZendeskApi_v2/Extensions/RequestExtensions.cs
@@ -46,6 +46,11 @@ namespace ZendeskApi_v2.Extensions
             return string.Join(",", ids.Select(x => x.ToString(CultureInfo.InvariantCulture)).ToArray());
         }
 
+        public static string ToCsv(this IEnumerable<string> ids)
+        {
+            return string.Join(",", ids.Select(x => x.ToString(CultureInfo.InvariantCulture)).ToArray());
+        }
+
         public static T ConvertToObject<T>(this string json)
         {
             var obj = JsonConvert.DeserializeObject<T>(json);

--- a/ZendeskApi_v2/Extensions/RequestExtensions.cs
+++ b/ZendeskApi_v2/Extensions/RequestExtensions.cs
@@ -48,7 +48,7 @@ namespace ZendeskApi_v2.Extensions
 
         public static string ToCsv(this IEnumerable<string> ids)
         {
-            return string.Join(",", ids.Select(x => x.ToString(CultureInfo.InvariantCulture)).ToArray());
+            return string.Join(",", ids.ToArray());
         }
 
         public static T ConvertToObject<T>(this string json)

--- a/ZendeskApi_v2/Models/Requests/GroupCommentResponse.cs
+++ b/ZendeskApi_v2/Models/Requests/GroupCommentResponse.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using ZendeskApi_v2.Models.Organizations;
 using ZendeskApi_v2.Models.Tickets;
+using ZendeskApi_v2.Models.Users;
 
 namespace ZendeskApi_v2.Models.Requests
 {
@@ -8,5 +10,11 @@ namespace ZendeskApi_v2.Models.Requests
     {
         [JsonProperty("comments")]
         public IList<Comment> Comments { get; set; }
+
+        [JsonProperty("users")]
+        public IList<User> Users { get; set; }
+
+        [JsonProperty("organizations")]
+        public IList<Organization> Organizations { get; set; }
     }
 }

--- a/ZendeskApi_v2/Models/Search/Result.cs
+++ b/ZendeskApi_v2/Models/Search/Result.cs
@@ -75,7 +75,7 @@ namespace ZendeskApi_v2.Models.Search
         public DateTimeOffset? UpdatedAt { get; set; }
 
         [JsonProperty("id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// Can be: ticket, user, group, organization, or topic

--- a/ZendeskApi_v2/Models/Users/GroupUserResponse.cs
+++ b/ZendeskApi_v2/Models/Users/GroupUserResponse.cs
@@ -1,10 +1,26 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using ZendeskApi_v2.Models.Organizations;
 
 namespace ZendeskApi_v2.Models.Users
 {
     public class GroupUserResponse : GroupResponseBase
     {
+
+        [JsonProperty("organizations")]
+        public IList<Organization> Organizations { get; set; }
+
+        //[JsonProperty("abilities")]
+        //public IList<Ability> Abilities { get; set; }
+
+        //[JsonProperty("roles")]
+        //public IList<Role> Roles { get; set; }
+
+        [JsonProperty("identities")]
+        public IList<UserIdentity> Identities { get; set; }
+
+        [JsonProperty("groups")]
+        public IList<Groups.Group> Groups { get; set; }
 
         [JsonProperty("users")]
         public IList<User> Users { get; set; }

--- a/ZendeskApi_v2/Models/Users/UserIdentity.cs
+++ b/ZendeskApi_v2/Models/Users/UserIdentity.cs
@@ -17,7 +17,7 @@ namespace ZendeskApi_v2.Models.Users
         public long? Id { get; set; }
 
         [JsonProperty("user_id")]
-        public int UserId { get; set; }
+        public long UserId { get; set; }
 
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/ZendeskApi_v2/Requests/Tickets.cs
+++ b/ZendeskApi_v2/Requests/Tickets.cs
@@ -46,7 +46,7 @@ namespace ZendeskApi_v2.Requests
         GroupTicketResponse GetTicketsByUserID(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         GroupTicketResponse GetTicketsWhereUserIsCopied(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         IndividualTicketResponse GetTicket(long id, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
-        GroupCommentResponse GetTicketComments(long ticketId, int? perPage = null, int? page = null);
+        GroupCommentResponse GetTicketComments(long ticketId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         GroupTicketResponse GetMultipleTickets(IEnumerable<long> ids, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         IndividualTicketResponse CreateTicket(Ticket ticket);
 
@@ -106,7 +106,7 @@ namespace ZendeskApi_v2.Requests
         Task<GroupTicketResponse> GetTicketsByUserIDAsync(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         Task<GroupTicketResponse> GetTicketsWhereUserIsCopiedAsync(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         Task<IndividualTicketResponse> GetTicketAsync(long id, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
-        Task<GroupCommentResponse> GetTicketCommentsAsync(long ticketId, int? perPage = null, int? page = null);
+        Task<GroupCommentResponse> GetTicketCommentsAsync(long ticketId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         Task<GroupTicketResponse> GetMultipleTicketsAsync(IEnumerable<long> ids, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         Task<IndividualTicketResponse> CreateTicketAsync(Ticket ticket);
 
@@ -268,9 +268,10 @@ namespace ZendeskApi_v2.Requests
             return GenericGet<IndividualTicketResponse>(resource);
         }
 
-        public GroupCommentResponse GetTicketComments(long ticketId, int? perPage = null, int? page = null)
+        public GroupCommentResponse GetTicketComments(long ticketId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
         {
-            return GenericPagedGet<GroupCommentResponse>(string.Format("{0}/{1}/comments.json", _tickets, ticketId), perPage, page);
+            string resource = GetResourceStringWithSideLoadOptionsParam(string.Format("{0}/{1}/comments.json", _tickets, ticketId), sideLoadOptions);
+            return GenericPagedGet<GroupCommentResponse>(resource, perPage, page);
         }
 
         public GroupTicketResponse GetMultipleTickets(IEnumerable<long> ids, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
@@ -539,9 +540,10 @@ namespace ZendeskApi_v2.Requests
             return await GenericGetAsync<IndividualTicketResponse>(resource);
         }
 
-        public async Task<GroupCommentResponse> GetTicketCommentsAsync(long ticketId, int? perPage = null, int? page = null)
+        public async Task<GroupCommentResponse> GetTicketCommentsAsync(long ticketId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
         {
-            return await GenericPagedGetAsync<GroupCommentResponse>(string.Format("{0}/{1}/comments.json", _tickets, ticketId), perPage, page);
+            string resource = GetResourceStringWithSideLoadOptionsParam(string.Format("{0}/{1}/comments.json", _tickets, ticketId), sideLoadOptions);
+            return await GenericPagedGetAsync<GroupCommentResponse>(resource, perPage, page);
         }
 
         public async Task<GroupTicketResponse> GetMultipleTicketsAsync(IEnumerable<long> ids, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)


### PR DESCRIPTION
Implement MergeUser/Async
Implement GetMultipleUsers/Async
Implement Side-Loading for GetAllUsers and GetMulipleUsers
Change SearchResult.Id from int to long
Change UserIdentity.UserId from int to long
Implemented UpdateUserIdentity, but in documentation it uses the same endpoint as AddUserIdentity

Unit Tests.