### PR TITLE
Make GroupTagResult Pageable

### DIFF
--- a/ZendeskApi_v2/Models/Tags/GroupTagResult.cs
+++ b/ZendeskApi_v2/Models/Tags/GroupTagResult.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Linq;
 namespace ZendeskApi_v2.Models.Tags
 {
 
-    public class GroupTagResult
+    public class GroupTagResult : GroupResponseBase
     {
         [JsonProperty("tags")]
         public IList<Tag> Tags { get; set; }


### PR DESCRIPTION
Inherit from GroupResponseBase in GroupTagResult in order to page
through when there are more than 100 Tags