### PR TITLE
Add support to get tickets by assigned

### DIFF
--- a/src/Tests/TicketTests.cs
+++ b/src/Tests/TicketTests.cs
@@ -265,7 +265,43 @@ namespace Tests
             Assert.IsTrue(ticketsRes.Result.Users.Any());
             Assert.IsTrue(ticketsRes.Result.Organizations.Any());
         }
-        
+
+        [Test]
+        public void CanAssignedTicketsByUserIdPaged() 
+        {
+            var ticketsRes = api.Tickets.GetAssignedTicketsByUserID( Settings.UserId, 5, 2 );
+
+            Assert.AreEqual( 5, ticketsRes.PageSize );
+            Assert.AreEqual( 5, ticketsRes.Tickets.Count );
+            Assert.Greater( ticketsRes.Count, 0 );
+
+            var nextPage = ticketsRes.NextPage.GetQueryStringDict()
+                    .Where( x => x.Key == "page" )
+                        .Select( x => x.Value )
+                        .FirstOrDefault();
+
+            Assert.NotNull( nextPage );
+
+            Assert.AreEqual( "3", nextPage );
+        }
+
+        [Test]
+        public void CanAssignedTicketsByUserIdPagedWithSideLoad() 
+        {
+            CanTicketsByUserIdPaged();
+            var ticketsRes = api.Tickets.GetAssignedTicketsByUserID( Settings.UserId, 5, 2, sideLoadOptions: ticketSideLoadOptions );
+            Assert.IsTrue( ticketsRes.Users.Any() );
+            Assert.IsTrue( ticketsRes.Organizations.Any() );
+        }
+
+        [Test]
+        public void CanAssignedTicketsByUserIdPagedAsyncWithSideLoad() 
+        {
+            var ticketsRes = api.Tickets.GetAssignedTicketsByUserIDAsync( Settings.UserId, 5, 2, sideLoadOptions: ticketSideLoadOptions );
+            Assert.IsTrue( ticketsRes.Result.Users.Any() );
+            Assert.IsTrue( ticketsRes.Result.Organizations.Any() );
+        }
+
         [Test]
         public void CanGetMultipleTickets()
         {

--- a/src/ZendeskApi_v2/Requests/Tickets.cs
+++ b/src/ZendeskApi_v2/Requests/Tickets.cs
@@ -44,6 +44,7 @@ namespace ZendeskApi_v2.Requests
         GroupTicketResponse GetTicketsByOrganizationID(long id, int pageNumber, int itemsPerPage, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         GroupTicketResponse GetRecentTickets(int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         GroupTicketResponse GetTicketsByUserID(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
+        GroupTicketResponse GetAssignedTicketsByUserID( long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None );
         GroupTicketResponse GetTicketsWhereUserIsCopied(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         IndividualTicketResponse GetTicket(long id, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         GroupCommentResponse GetTicketComments(long ticketId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
@@ -106,6 +107,7 @@ namespace ZendeskApi_v2.Requests
         Task<GroupTicketResponse> GetTicketsByOrganizationIDAsync(long id, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         Task<GroupTicketResponse> GetRecentTicketsAsync(int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         Task<GroupTicketResponse> GetTicketsByUserIDAsync(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
+        Task<GroupTicketResponse> GetAssignedTicketsByUserIDAsync( long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None );
         Task<GroupTicketResponse> GetTicketsWhereUserIsCopiedAsync(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         Task<IndividualTicketResponse> GetTicketAsync(long id, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
         Task<GroupCommentResponse> GetTicketCommentsAsync(long ticketId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
@@ -258,6 +260,11 @@ namespace ZendeskApi_v2.Requests
         {
             string resource = GetResourceStringWithSideLoadOptionsParam(string.Format("users/{0}/tickets/requested.json", userId), sideLoadOptions);
             return GenericPagedGet<GroupTicketResponse>(resource, perPage, page);
+        }
+        public GroupTicketResponse GetAssignedTicketsByUserID( long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None ) 
+        {
+            string resource = GetResourceStringWithSideLoadOptionsParam( string.Format( "users/{0}/tickets/assigned.json", userId ), sideLoadOptions );
+            return GenericPagedGet<GroupTicketResponse>( resource, perPage, page );
         }
 
         public GroupTicketResponse GetTicketsWhereUserIsCopied(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
@@ -570,6 +577,11 @@ namespace ZendeskApi_v2.Requests
             return await GenericPagedGetAsync<GroupTicketResponse>(resource, perPage, page);
         }
 
+        public async Task<GroupTicketResponse> GetAssignedTicketsByUserIDAsync( long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None ) 
+        {
+          string resource = GetResourceStringWithSideLoadOptionsParam( string.Format( "users/{0}/tickets/assigned.json", userId ), sideLoadOptions );
+          return await GenericPagedGetAsync<GroupTicketResponse>( resource, perPage, page );
+        }
         public async Task<GroupTicketResponse> GetTicketsWhereUserIsCopiedAsync(long userId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
         {
             string resource = GetResourceStringWithSideLoadOptionsParam(string.Format("users/{0}/tickets/ccd.json", userId), sideLoadOptions);


### PR DESCRIPTION
I added a method called `GetAssignedTicketsByUserID` which will return a list of tickets that are assigned to that user. I noticed this functionality was missing and it was just a matter of changing the url to `users/{id}/tickets/assigned.json` which is supported by the Zendesk API.

I also added 3 unit tests which were copy and pasts of the GetTicketsByUserIDTests

API Reference: https://developer.zendesk.com/rest_api/docs/core/tickets#list-tickets