### PR TITLE
[WIP] Unit test and fix for #195, "Help Center CreateSection API endpoint not correct, cannot create new sections."

### DIFF
--- a/src/Tests/HelpCenter/SectionTests.cs
+++ b/src/Tests/HelpCenter/SectionTests.cs
@@ -25,9 +25,13 @@ namespace Tests.HelpCenter
 		[Test]
 		public void CanCreateUpdateAndDeleteSections()
 		{
+			//https://csharpapi.zendesk.com/hc/en-us/categories/200382245-Category-1
+			long category_id = 200382245;
+			
 			var res = api.HelpCenter.Sections.CreateSection( new Section()
 			{
-				Name = "My Test section"
+				Name = "My Test section",
+				CategoryId = category_id
 			} );
 			Assert.Greater( res.Section.Id, 0 );
 

--- a/src/Tests/HelpCenter/SectionTests.cs
+++ b/src/Tests/HelpCenter/SectionTests.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+using ZendeskApi_v2;
+using ZendeskApi_v2.Models.Sections;
+using ZendeskApi_v2.Requests.HelpCenter;
+
+namespace Tests.HelpCenter
+{
+	[TestFixture]
+	[Category( "HelpCenter" )]
+	class SectionTests
+	{
+		private ZendeskApi api = new ZendeskApi( Settings.Site, Settings.Email, Settings.Password );
+
+		[Test]
+
+		public void CanGetSections()
+		{
+			var res = api.HelpCenter.Sections.GetSections();
+			Assert.Greater( res.Count, 0 );
+
+			var res1 = api.HelpCenter.Sections.GetSectionById( res.Sections[ 0 ].Id.Value );
+			Assert.AreEqual( res1.Section.Id, res.Sections[ 0 ].Id.Value );
+		}
+
+		[Test]
+		public void CanCreateUpdateAndDeleteSections()
+		{
+			var res = api.HelpCenter.Sections.CreateSection( new Section()
+			{
+				Name = "My Test section"
+			} );
+			Assert.Greater( res.Section.Id, 0 );
+
+			res.Section.Description = "updated description";
+			var update = api.HelpCenter.Sections.UpdateSection( res.Section );
+			Assert.AreEqual( update.Section.Description, res.Section.Description );
+
+			Assert.True( api.HelpCenter.Sections.DeleteSection( res.Section.Id.Value ) );
+		}
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -87,6 +87,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HelpCenter\SectionTests.cs" />
     <Compile Include="HelpCenter\VoteTests.cs" />
     <Compile Include="HelpCenter\CommentTests.cs" />
     <Compile Include="HelpCenter\ArticleTests.cs" />

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
@@ -57,7 +57,7 @@ namespace ZendeskApi_v2.Requests.HelpCenter
         public IndividualSectionResponse CreateSection(Section section)
         {
 			var body = new { section };
-			return GenericPost<IndividualSectionResponse>(string.Format("help_center/sections.json"), body);
+			return GenericPost<IndividualSectionResponse>(string.Format( "help_center/categories/{0}/sections.json", section.CategoryId ), body);
         }
 
         public IndividualSectionResponse UpdateSection(Section section)


### PR DESCRIPTION
In the first commit, I added two unit tests for Sections.

- CanGetSections
- CanCreateUpdateAndDeleteSections
https://github.com/Marcus10110/ZendeskApi_v2/commit/8ca94c0c9339a4521585ce4a546d97463107a663

The second test, CanCreateUpdateAndDeleteSections fails with an error about the endpoint.

The second commit (head) includes the fix for this issue, and also updates the unit test, as a category ID is now required by the API. Both tests now pass.