### PR TITLE
Adding support for translations

### DIFF
--- a/src/Tests/HelpCenter/ArticleTests.cs
+++ b/src/Tests/HelpCenter/ArticleTests.cs
@@ -19,7 +19,15 @@ namespace Tests.HelpCenter
             Assert.IsNotNull(res.Arcticle);
         }
 
-        [Test]
+		[Test]
+		public void CanGetSingleArticleWithTranslations()
+		{
+			var res = api.HelpCenter.Articles.GetArticle( _articleIdWithComments, ArticleSideLoadOptionsEnum.Translations );
+			Assert.IsNotNull( res.Arcticle );
+			Assert.Greater( res.Arcticle.Translations.Count, 0 );
+		}
+
+		[Test]
         public void CanGetArticles()
         {
             var res = api.HelpCenter.Articles.GetArticles();
@@ -139,7 +147,15 @@ namespace Tests.HelpCenter
             Assert.True(api.HelpCenter.Articles.DeleteArticle(res.Arcticle.Id.Value));
         }
 
-        [Test]
+		[Test]
+		public void CanGetSingleArticleWithTranslationsAsync()
+		{
+			var res = api.HelpCenter.Articles.GetArticleAsync( _articleIdWithComments, ArticleSideLoadOptionsEnum.Translations ).Result;
+			Assert.IsNotNull( res.Arcticle );
+			Assert.Greater( res.Arcticle.Translations.Count, 0 );
+		}
+
+		[Test]
         public void CanGetArticlesAsync()
         {
             var res = api.HelpCenter.Articles.GetArticlesAsync().Result;

--- a/src/Tests/HelpCenter/TranslationTests.cs
+++ b/src/Tests/HelpCenter/TranslationTests.cs
@@ -1,0 +1,206 @@
+﻿using NUnit.Framework;
+using ZendeskApi_v2;
+using ZendeskApi_v2.Models.HelpCenter.Translations;
+
+namespace Tests.HelpCenter
+{
+	[TestFixture]
+	[Category( "HelpCenter" )]
+	public class TranslationTests
+	{
+		private ZendeskApi api = new ZendeskApi( Settings.Site, Settings.Email, Settings.Password );
+		private long _articleId = 204838115; //https://csharpapi.zendesk.com/hc/en-us/articles/204838115-Thing-4?page=1#comment_200486479
+		private long _sectionId = 201010935;
+		private long _categoryId = 200382245;
+		[ Test]
+		public void CanListTranslations()
+		{
+			
+			var res = api.HelpCenter.Translations.ListTranslationsForArticle( _articleId );
+			Assert.AreEqual( 2, res.Count );
+
+			res = api.HelpCenter.Translations.ListTranslationsForSection( _sectionId );
+			Assert.AreEqual( 2, res.Count );
+
+			res = api.HelpCenter.Translations.ListTranslationsForCategory( _categoryId );
+			Assert.AreEqual( 2, res.Count );
+
+
+		}
+
+		[Test]
+		public void CanShowTranslationForArticle()
+		{
+			var res = api.HelpCenter.Translations.ShowTranslationForArticle( _articleId, "en-us" );
+			Assert.AreEqual( "en-us" , res.Translation.Locale );			
+		}
+
+		[Test]
+		public void CanListMissingCreateUpdateAndDeleteTranslationsForArticle()
+		{
+			//create an article with en-us locale.
+			//verify that fr is missing.
+			//add a translation and verify.
+			//update translation and verify.
+			//delete translation and verify.
+			//delete new article.
+
+			//prep
+			var resSections = api.HelpCenter.Sections.GetSections();
+			var new_article_res = api.HelpCenter.Articles.CreateArticle( resSections.Sections[ 0 ].Id.Value, new ZendeskApi_v2.Models.Articles.Article()
+			{
+				Title = "My Test article for translations",
+				Body = "The body of my article",
+				Locale = "en-us"
+			} );
+			long article_id = new_article_res.Arcticle.Id.Value;
+
+			var missing_res = api.HelpCenter.Translations.ListMissingTranslationsForArticle( article_id );
+			Assert.AreEqual( 1, missing_res.Count );
+			Assert.AreEqual( "fr", missing_res[ 0 ] );
+
+			Translation fr_translation = new Translation()
+			{
+				Body = "Je ne parle pas français.",
+				Title = "Mon article de test pour les traductions",
+				Locale = "fr"
+			};
+
+			//create translation
+			var add_res = api.HelpCenter.Translations.CreateArticleTranslation( article_id, fr_translation );
+			Assert.Greater( add_res.Translation.Id, 0 );
+
+			add_res.Translation.Body = "insérer plus français ici .";
+
+			//update translation
+			var update_res = api.HelpCenter.Translations.UpdateArticleTranslation( add_res.Translation );
+			Assert.AreEqual( "insérer plus français ici .", update_res.Translation.Body );
+
+			//delete translation
+			Assert.IsTrue( api.HelpCenter.Translations.DeleteTranslation( update_res.Translation.Id.Value ) );
+
+			//teardown.
+			Assert.IsTrue( api.HelpCenter.Articles.DeleteArticle( article_id ) );
+
+		}
+
+		[Test]
+		public void CanListMissingCreateUpdateAndDeleteTranslationsForSection()
+		{
+			//first, merge in fix for categories.
+			Assert.Fail();
+			//create a section with en-us locale.
+			//verify that fr is missing.
+			//add a translation and verify.
+			//update translation and verify.
+			//delete translation and verify.
+			//delete new section.
+
+			//prep
+			var resCategoies = api.HelpCenter.Categories.GetCategories();
+			var new_section_res = api.HelpCenter.Sections.CreateSection( null /*new ZendeskApi_v2.Models.HelpCenter()
+			{
+				Name = "My Test section for translations",
+				Description = "The body of my section (en-us)",
+				Locale = "en-us"
+			}*/ );
+			long section_id = new_section_res.Section.Id.Value;
+
+			var missing_res = api.HelpCenter.Translations.ListMissingTranslationsForSection( section_id );
+			Assert.AreEqual( 1, missing_res.Count );
+			Assert.AreEqual( "fr", missing_res[ 0 ] );
+
+			Translation fr_translation = new Translation()
+			{
+				Body = "Je ne parle pas français.",
+				Title = "french category here",
+				Locale = "fr"
+			};
+
+			//create translation
+			var add_res = api.HelpCenter.Translations.CreateSectionTranslation( section_id, fr_translation );
+			Assert.Greater( add_res.Translation.Id, 0 );
+
+			add_res.Translation.Body = "insérer plus français ici .";
+
+			//update translation
+			var update_res = api.HelpCenter.Translations.UpdateSectionTranslation( add_res.Translation );
+			Assert.AreEqual( "insérer plus français ici .", update_res.Translation.Body );
+
+			//delete translation
+			Assert.IsTrue( api.HelpCenter.Translations.DeleteTranslation( update_res.Translation.Id.Value ) );
+
+			//teardown.
+			Assert.IsTrue( api.HelpCenter.Sections.DeleteSection( section_id ) );
+
+		}
+
+		[Test]
+		public void CanListMissingCreateUpdateAndDeleteTranslationsForCategory()
+		{
+			//create a category with en-us locale.
+			//verify that fr is missing.
+			//add a translation and verify.
+			//update translation and verify.
+			//delete translation and verify.
+			//delete new category.
+
+
+			//prep
+			var new_category_res = api.HelpCenter.Categories.CreateCategory(  new ZendeskApi_v2.Models.HelpCenter.Categories.Category()
+			{
+				Name = "My Test category for translations",
+				Description = "The body of my category (en-us)",
+				Locale = "en-us"
+			} );
+			long category_id = new_category_res.Category.Id.Value;
+
+			var missing_res = api.HelpCenter.Translations.ListMissingTranslationsForCategory( category_id );
+			Assert.AreEqual( 1, missing_res.Count );
+			Assert.AreEqual( "fr", missing_res[ 0 ] );
+
+			Translation fr_translation = new Translation()
+			{
+				Body = "Je ne parle pas français.",
+				Title = "french for 'this is a french category'",
+				Locale = "fr"
+			};
+
+			//create translation
+			var add_res = api.HelpCenter.Translations.CreateCategoryTranslation( category_id, fr_translation );
+			Assert.Greater( add_res.Translation.Id, 0 );
+
+			add_res.Translation.Body = "insérer plus français ici . (category)";
+
+			//update translation
+			var update_res = api.HelpCenter.Translations.UpdateCategoryTranslation( add_res.Translation );
+			Assert.AreEqual( "insérer plus français ici . (category)", update_res.Translation.Body );
+
+			//delete translation
+			Assert.IsTrue( api.HelpCenter.Translations.DeleteTranslation( update_res.Translation.Id.Value ) );
+
+			//teardown.
+			Assert.IsTrue( api.HelpCenter.Categories.DeleteCategory( category_id ) );
+
+		}
+
+		[Test]
+		public void CanListAllEnabledLocales()
+		{
+			//the only two locales enabled on the test site are us-en and fr. us-en is the default.
+			//note: FR was already enabled in the Zendesk settings, however it had to be enabled again in the help center preferences.
+			string default_locale;
+			var res = api.HelpCenter.Translations.ListAllEnabledLocalesAndDefaultLocale( out default_locale );
+
+			Assert.AreEqual( default_locale, "en-us" );
+			Assert.IsTrue( res.Contains( "en-us" ) );
+			Assert.IsTrue( res.Contains( "fr" ) );
+			Assert.AreEqual( res.Count, 2 );
+
+		}
+
+
+
+
+	}
+}

--- a/src/Tests/HelpCenter/TranslationTests.cs
+++ b/src/Tests/HelpCenter/TranslationTests.cs
@@ -15,7 +15,6 @@ namespace Tests.HelpCenter
 		[ Test]
 		public void CanListTranslations()
 		{
-			
 			var res = api.HelpCenter.Translations.ListTranslationsForArticle( _articleId );
 			Assert.AreEqual( 2, res.Count );
 
@@ -24,8 +23,6 @@ namespace Tests.HelpCenter
 
 			res = api.HelpCenter.Translations.ListTranslationsForCategory( _categoryId );
 			Assert.AreEqual( 2, res.Count );
-
-
 		}
 
 		[Test]
@@ -194,11 +191,191 @@ namespace Tests.HelpCenter
 			Assert.AreEqual( default_locale, "en-us" );
 			Assert.IsTrue( res.Contains( "en-us" ) );
 			Assert.IsTrue( res.Contains( "fr" ) );
-			Assert.AreEqual( res.Count, 2 );
-
 		}
 
 
+		//Async tests:
+
+
+		[Test]
+		public void CanListTranslationsAsync()
+		{
+			var res = api.HelpCenter.Translations.ListTranslationsForArticleAsync( _articleId ).Result;
+			Assert.AreEqual( 2, res.Count );
+
+			res = api.HelpCenter.Translations.ListTranslationsForSectionAsync( _sectionId ).Result;
+			Assert.AreEqual( 2, res.Count );
+
+			res = api.HelpCenter.Translations.ListTranslationsForCategoryAsync( _categoryId ).Result;
+			Assert.AreEqual( 2, res.Count );
+		}
+
+		[Test]
+		public void CanShowTranslationForArticleAsync()
+		{
+			var res = api.HelpCenter.Translations.ShowTranslationForArticleAsync( _articleId, "en-us" ).Result;
+			Assert.AreEqual( "en-us", res.Translation.Locale );
+		}
+
+		[Test]
+		public void CanListMissingCreateUpdateAndDeleteTranslationsForArticleAsync()
+		{
+			//create an article with en-us locale.
+			//verify that fr is missing.
+			//add a translation and verify.
+			//update translation and verify.
+			//delete translation and verify.
+			//delete new article.
+
+			//prep
+			var resSections = api.HelpCenter.Sections.GetSectionsAsync().Result;
+			var new_article_res = api.HelpCenter.Articles.CreateArticleAsync( resSections.Sections[ 0 ].Id.Value, new ZendeskApi_v2.Models.Articles.Article()
+			{
+				Title = "My Test article for translations",
+				Body = "The body of my article",
+				Locale = "en-us"
+			} ).Result;
+			long article_id = new_article_res.Arcticle.Id.Value;
+
+			var missing_res = api.HelpCenter.Translations.ListMissingTranslationsForArticleAsync( article_id ).Result;
+			Assert.AreEqual( 1, missing_res.Count );
+			Assert.AreEqual( "fr", missing_res[ 0 ] );
+
+			Translation fr_translation = new Translation()
+			{
+				Body = "Je ne parle pas français.",
+				Title = "Mon article de test pour les traductions",
+				Locale = "fr"
+			};
+
+			//create translation
+			var add_res = api.HelpCenter.Translations.CreateArticleTranslationAsync( article_id, fr_translation ).Result;
+			Assert.Greater( add_res.Translation.Id, 0 );
+
+			add_res.Translation.Body = "insérer plus français ici .";
+
+			//update translation
+			var update_res = api.HelpCenter.Translations.UpdateArticleTranslationAsync( add_res.Translation ).Result;
+			Assert.AreEqual( "insérer plus français ici .", update_res.Translation.Body );
+
+			//delete translation
+			Assert.IsTrue( api.HelpCenter.Translations.DeleteTranslationAsync( update_res.Translation.Id.Value ).Result );
+
+			//teardown.
+			Assert.IsTrue( api.HelpCenter.Articles.DeleteArticleAsync( article_id ).Result );
+
+		}
+
+		[Test]
+		public void CanListMissingCreateUpdateAndDeleteTranslationsForSectionAsync()
+		{
+			//create a section with en-us locale.
+			//verify that fr is missing.
+			//add a translation and verify.
+			//update translation and verify.
+			//delete translation and verify.
+			//delete new section.
+
+			//prep
+			var resCategoies = api.HelpCenter.Categories.GetCategoriesAsync().Result;
+			var new_section_res = api.HelpCenter.Sections.CreateSectionAsync( new ZendeskApi_v2.Models.Sections.Section()
+			{
+				Name = "My Test section for translations",
+				Description = "The body of my section (en-us)",
+				Locale = "en-us",
+				CategoryId = resCategoies.Categories[ 0 ].Id.Value
+			} ).Result;
+			long section_id = new_section_res.Section.Id.Value;
+
+			var missing_res = api.HelpCenter.Translations.ListMissingTranslationsForSectionAsync( section_id ).Result;
+			Assert.AreEqual( 1, missing_res.Count );
+			Assert.AreEqual( "fr", missing_res[ 0 ] );
+
+			Translation fr_translation = new Translation()
+			{
+				Body = "Je ne parle pas français.",
+				Title = "french category here",
+				Locale = "fr"
+			};
+
+			//create translation
+			var add_res = api.HelpCenter.Translations.CreateSectionTranslationAsync( section_id, fr_translation ).Result;
+			Assert.Greater( add_res.Translation.Id, 0 );
+
+			add_res.Translation.Body = "insérer plus français ici .";
+
+			//update translation
+			var update_res = api.HelpCenter.Translations.UpdateSectionTranslationAsync( add_res.Translation ).Result;
+			Assert.AreEqual( "insérer plus français ici .", update_res.Translation.Body );
+
+			//delete translation
+			Assert.IsTrue( api.HelpCenter.Translations.DeleteTranslationAsync( update_res.Translation.Id.Value ).Result );
+
+			//teardown.
+			Assert.IsTrue( api.HelpCenter.Sections.DeleteSectionAsync( section_id ).Result );
+
+		}
+
+		[Test]
+		public void CanListMissingCreateUpdateAndDeleteTranslationsForCategoryAsync()
+		{
+			//create a category with en-us locale.
+			//verify that fr is missing.
+			//add a translation and verify.
+			//update translation and verify.
+			//delete translation and verify.
+			//delete new category.
+
+
+			//prep
+			var new_category_res = api.HelpCenter.Categories.CreateCategoryAsync( new ZendeskApi_v2.Models.HelpCenter.Categories.Category()
+			{
+				Name = "My Test category for translations",
+				Description = "The body of my category (en-us)",
+				Locale = "en-us"
+			} ).Result;
+			long category_id = new_category_res.Category.Id.Value;
+
+			var missing_res = api.HelpCenter.Translations.ListMissingTranslationsForCategoryAsync( category_id ).Result;
+			Assert.AreEqual( 1, missing_res.Count );
+			Assert.AreEqual( "fr", missing_res[ 0 ] );
+
+			Translation fr_translation = new Translation()
+			{
+				Body = "Je ne parle pas français.",
+				Title = "french for 'this is a french category'",
+				Locale = "fr"
+			};
+
+			//create translation
+			var add_res = api.HelpCenter.Translations.CreateCategoryTranslationAsync( category_id, fr_translation ).Result;
+			Assert.Greater( add_res.Translation.Id, 0 );
+
+			add_res.Translation.Body = "insérer plus français ici . (category)";
+
+			//update translation
+			var update_res = api.HelpCenter.Translations.UpdateCategoryTranslationAsync( add_res.Translation ).Result;
+			Assert.AreEqual( "insérer plus français ici . (category)", update_res.Translation.Body );
+
+			//delete translation
+			Assert.IsTrue( api.HelpCenter.Translations.DeleteTranslationAsync( update_res.Translation.Id.Value ).Result );
+
+			//teardown.
+			Assert.IsTrue( api.HelpCenter.Categories.DeleteCategoryAsync( category_id ).Result );
+
+		}
+
+		[Test]
+		public void CanListAllEnabledLocalesAsync()
+		{
+			//the only two locales enabled on the test site are us-en and fr. us-en is the default.
+			//note: FR was already enabled in the Zendesk settings, however it had to be enabled again in the help center preferences.
+			var res = api.HelpCenter.Translations.ListAllEnabledLocalesAndDefaultLocaleAsync(  ).Result;
+
+			Assert.AreEqual( res.Item2, "en-us" );
+			Assert.IsTrue( res.Item1.Contains( "en-us" ) );
+			Assert.IsTrue( res.Item1.Contains( "fr" ) );
+		}
 
 
 	}

--- a/src/Tests/HelpCenter/TranslationTests.cs
+++ b/src/Tests/HelpCenter/TranslationTests.cs
@@ -87,8 +87,6 @@ namespace Tests.HelpCenter
 		[Test]
 		public void CanListMissingCreateUpdateAndDeleteTranslationsForSection()
 		{
-			//first, merge in fix for categories.
-			Assert.Fail();
 			//create a section with en-us locale.
 			//verify that fr is missing.
 			//add a translation and verify.
@@ -98,12 +96,13 @@ namespace Tests.HelpCenter
 
 			//prep
 			var resCategoies = api.HelpCenter.Categories.GetCategories();
-			var new_section_res = api.HelpCenter.Sections.CreateSection( null /*new ZendeskApi_v2.Models.HelpCenter()
+			var new_section_res = api.HelpCenter.Sections.CreateSection( new ZendeskApi_v2.Models.Sections.Section()
 			{
 				Name = "My Test section for translations",
 				Description = "The body of my section (en-us)",
-				Locale = "en-us"
-			}*/ );
+				Locale = "en-us",
+				CategoryId = resCategoies.Categories[ 0 ].Id.Value
+			} );
 			long section_id = new_section_res.Section.Id.Value;
 
 			var missing_res = api.HelpCenter.Translations.ListMissingTranslationsForSection( section_id );

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -87,6 +87,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HelpCenter\TranslationTests.cs" />
     <Compile Include="HelpCenter\VoteTests.cs" />
     <Compile Include="HelpCenter\CommentTests.cs" />
     <Compile Include="HelpCenter\ArticleTests.cs" />

--- a/src/ZendeskApi_v2/HelpCenterApi.cs
+++ b/src/ZendeskApi_v2/HelpCenterApi.cs
@@ -6,7 +6,8 @@ namespace ZendeskApi_v2.HelpCenter
         ICategories Categories { get; }
         ISections Sections { get; }
         IArticles Articles { get; }
-        IVotes Votes { get; }
+		ITranslations Translations { get; }
+		IVotes Votes { get; }
         IComments Comments { get; }
 
         string Locale { get; }
@@ -17,7 +18,8 @@ namespace ZendeskApi_v2.HelpCenter
         public ICategories Categories { get; set; }
         public ISections Sections { get; set; }
         public IArticles Articles { get; set; }
-        public IVotes Votes { get; set; }
+		public ITranslations Translations { get; set; }
+		public IVotes Votes { get; set; }
         public IComments Comments { get; set; }
 
         public string Locale { get; set; }
@@ -27,7 +29,8 @@ namespace ZendeskApi_v2.HelpCenter
             Categories = new Categories(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken);
             Sections = new Sections(yourZendeskUrl, user, password, apiToken, p_OAuthToken);
             Articles = new Articles(yourZendeskUrl, user, password, apiToken, p_OAuthToken);
-            Votes = new Votes(yourZendeskUrl, user, password, apiToken, p_OAuthToken);
+			Translations = new Translations( yourZendeskUrl, user, password, apiToken, p_OAuthToken );
+			Votes = new Votes(yourZendeskUrl, user, password, apiToken, p_OAuthToken);
             Comments = new Comments(yourZendeskUrl, user, password, apiToken, p_OAuthToken);
 
             Locale = locale;

--- a/src/ZendeskApi_v2/Models/HelpCenter/Translations/GroupTranslationResponse.cs
+++ b/src/ZendeskApi_v2/Models/HelpCenter/Translations/GroupTranslationResponse.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+
+namespace ZendeskApi_v2.Models.HelpCenter.Translations
+{
+	public class GroupTranslationResponse : GroupResponseBase
+	{
+
+		[JsonProperty( "translations" )]
+		public IList<Translations.Translation> Translations { get; set; }
+		
+	}
+}

--- a/src/ZendeskApi_v2/Models/HelpCenter/Translations/IndividualTranslationResponse.cs
+++ b/src/ZendeskApi_v2/Models/HelpCenter/Translations/IndividualTranslationResponse.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace ZendeskApi_v2.Models.HelpCenter.Translations
+{
+	public class IndividualTranslationResponse
+	{
+		[JsonProperty( "translation" )]
+		public Translation Translation { get; set; }
+	}
+}

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Articles.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Articles.cs
@@ -23,8 +23,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
     public interface IArticles : ICore
     {
 #if SYNC
-        IndividualArticleResponse GetArticle(long articleId);
-        GroupArticleResponse GetArticles(ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None, ArticleSortingOptions options = null, int? perPage = null, int? page = null);
+        IndividualArticleResponse GetArticle(long articleId, ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None );
+		GroupArticleResponse GetArticles(ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None, ArticleSortingOptions options = null, int? perPage = null, int? page = null);
         GroupArticleResponse GetArticlesByCategoryId(long categoryId, ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None, ArticleSortingOptions options = null);
         GroupArticleResponse GetArticlesBySectionId(long sectionId, ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None, ArticleSortingOptions options = null);
         GroupArticleResponse GetArticlesByUserId(long userId);
@@ -57,9 +57,11 @@ namespace ZendeskApi_v2.Requests.HelpCenter
         }
 
 #if SYNC
-        public IndividualArticleResponse GetArticle(long articleId)
+        public IndividualArticleResponse GetArticle(long articleId, ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None )
         {
-            return GenericGet<IndividualArticleResponse>(string.Format("help_center/articles/{0}.json", articleId));
+			var resourceUrl = this.GetFormattedArticleUri( string.Format( "help_center/articles/{0}.json", articleId ), sideloadOptions );
+
+            return GenericGet<IndividualArticleResponse>( resourceUrl );
         }
 
         public GroupArticleResponse GetArticles(ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None, ArticleSortingOptions options = null, int? perPage = null, int? page = null)
@@ -228,5 +230,24 @@ namespace ZendeskApi_v2.Requests.HelpCenter
             }
             return resourceUrl;
         }
-    }
+
+		private string GetFormattedArticleUri( string resourceUrl, ArticleSideLoadOptionsEnum sideloadOptions )
+		{
+		
+			string sideLoads = sideloadOptions.ToString().ToLower().Replace( " ", "" );
+			if( sideloadOptions != ArticleSideLoadOptionsEnum.None )
+			{
+				resourceUrl += resourceUrl.Contains( "?" ) ? "&include=" : "?include=";
+
+				//Categories flag REQUIRES sections to be added as well, or nothing will be returned
+				if( sideloadOptions.HasFlag( ArticleSideLoadOptionsEnum.Categories ) && !sideloadOptions.HasFlag( ArticleSideLoadOptionsEnum.Sections ) )
+				{
+					sideLoads += string.Format( ",{0}", ArticleSideLoadOptionsEnum.Sections.ToString().ToLower() );
+				}
+
+				resourceUrl += sideLoads;
+			}
+			return resourceUrl;
+		}
+	}
 }

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Articles.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Articles.cs
@@ -35,8 +35,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
         bool DeleteArticle(long id);
 #endif
 #if ASYNC
-        Task<IndividualArticleResponse> GetArticleAsync(long articleId);
-        Task<GroupArticleResponse> GetArticlesAsync(ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None, ArticleSortingOptions options = null, int? perPage = null, int? page = null);
+        Task<IndividualArticleResponse> GetArticleAsync( long articleId, ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None );
+		Task<GroupArticleResponse> GetArticlesAsync(ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None, ArticleSortingOptions options = null, int? perPage = null, int? page = null);
         Task<GroupArticleResponse> GetArticlesByCategoryIdAsync(long categoryId, ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None, ArticleSortingOptions options = null);
         Task<GroupArticleResponse> GetArticlesBySectionIdAsync(long sectionId, ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None, ArticleSortingOptions options = null);
         Task<GroupArticleResponse> GetArticlesByUserIdAsync(long userId);
@@ -132,9 +132,11 @@ namespace ZendeskApi_v2.Requests.HelpCenter
         }
 #endif
 #if ASYNC
-        public async Task<IndividualArticleResponse> GetArticleAsync(long articleId)
+        public async Task<IndividualArticleResponse> GetArticleAsync(long articleId, ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None )
         {
-            return await GenericPostAsync<IndividualArticleResponse>(string.Format("help_center/articles/{0}.json", articleId));
+			var resourceUrl = this.GetFormattedArticleUri( string.Format( "help_center/articles/{0}.json", articleId ), sideloadOptions );
+
+			return await GenericGetAsync<IndividualArticleResponse>( resourceUrl );
         }
 
         public async Task<GroupArticleResponse> GetArticlesAsync(ArticleSideLoadOptionsEnum sideloadOptions = ArticleSideLoadOptionsEnum.None, ArticleSortingOptions options = null, int? perPage = null, int? page = null)

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Translations.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Translations.cs
@@ -14,11 +14,15 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 	{
 #if SYNC
 
+		GroupTranslationResponse ListTranslationsForArticle( long articleId );
+		GroupTranslationResponse ListTranslationsForSection( long articleId );
+		GroupTranslationResponse ListTranslationsForCategory( long articleId );
+
 		IList<string> ListMissingTranslationsForArticle( long articleId );
 		IList<string> ListMissingTranslationsForSection( long articleId );
 		IList<string> ListMissingTranslationsForCategory( long articleId );
-		IList<string> ListAllEnabledLocalesAndDefaultLocale( out string defaultLocale );
 
+		IndividualTranslationResponse ShowTranslationForArticle( long articleId, string locale );
 
 		IndividualTranslationResponse CreateArticleTranslation( long articleId, Translation translation );
 		IndividualTranslationResponse CreateSectionTranslation( long SectionId, Translation translation );
@@ -29,6 +33,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 		IndividualTranslationResponse UpdateCategoryTranslation( Translation translation );
 
 		bool DeleteTranslation( long translationId );
+
+		IList<string> ListAllEnabledLocalesAndDefaultLocale( out string defaultLocale );
 #endif
 
 #if ASYNC
@@ -43,49 +49,70 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 		}
 
 #if SYNC
+		public GroupTranslationResponse ListTranslationsForArticle( long articleId )
+		{
+			var resourceUrl = String.Format( "/help_center/articles/{0}/translations.json", articleId );
+
+			return GenericGet<GroupTranslationResponse>( resourceUrl );
+		}
+
+		public GroupTranslationResponse ListTranslationsForSection( long articleId )
+		{
+			var resourceUrl = String.Format( "/help_center/sections/{0}/translations.json", articleId );
+
+			return GenericGet<GroupTranslationResponse>( resourceUrl );
+		}
+
+		public GroupTranslationResponse ListTranslationsForCategory( long articleId )
+		{
+			var resourceUrl = String.Format( "/help_center/categories/{0}/translations.json", articleId );
+
+			return GenericGet<GroupTranslationResponse>( resourceUrl );
+		}
+
+
 		public IList<string> ListMissingTranslationsForArticle( long articleId )
 		{
 			var res = RunRequest( String.Format( "help_center/articles/{0}/translations/missing.json", articleId ), "GET" );
 			var anon_type = new { locales = new List<string>() };
 			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Content, anon_type );
-			return anon_type.locales;
+			return locale_info.locales;
 		}
 		public IList<string> ListMissingTranslationsForSection( long articleId )
 		{
 			var res = RunRequest( String.Format( "help_center/sections/{0}/translations/missing.json", articleId ), "GET" );
 			var anon_type = new { locales = new List<string>() };
 			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Content, anon_type );
-			return anon_type.locales;
+			return locale_info.locales;
 		}
 		public IList<string> ListMissingTranslationsForCategory( long articleId )
 		{
 			var res = RunRequest( String.Format( "help_center/categories/{0}/translations/missing.json", articleId ), "GET" );
 			var anon_type = new { locales = new List<string>() };
 			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Content, anon_type );
-			return anon_type.locales;
-		}
-		public IList<string> ListAllEnabledLocalesAndDefaultLocale( out string defaultLocale )
-		{
-			var res = RunRequest( "help_center/locales.json", "GET" );
-			var anon_type = new { locales = new List<string>(), default_locale = "" };
-			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Content, anon_type );
-			defaultLocale = locale_info.default_locale;
 			return locale_info.locales;
 		}
+
+		public IndividualTranslationResponse ShowTranslationForArticle( long articleId, string locale )
+		{
+			var resourceUrl = String.Format( "/help_center/articles/{0}/translations/{1}.json", articleId, locale );
+			return GenericGet<IndividualTranslationResponse>( resourceUrl );
+		}
+
 		public IndividualTranslationResponse CreateArticleTranslation( long articleId, Translation translation )
 		{
 			var body = new { translation };
-			return GenericPost<IndividualTranslationResponse>( string.Format( "help_center/articles/{0}/translations.json", translation.SourceId ), body );
+			return GenericPost<IndividualTranslationResponse>( string.Format( "help_center/articles/{0}/translations.json", articleId ), body );
 		}
 		public IndividualTranslationResponse CreateSectionTranslation( long SectionId, Translation translation )
 		{
 			var body = new { translation };
-			return GenericPost<IndividualTranslationResponse>( string.Format( "help_center/sections/{0}/translations.json", translation.SourceId ), body );
+			return GenericPost<IndividualTranslationResponse>( string.Format( "help_center/sections/{0}/translations.json", SectionId ), body );
 		}
 		public IndividualTranslationResponse CreateCategoryTranslation( long CategoryId, Translation translation )
 		{
 			var body = new { translation };
-			return GenericPost<IndividualTranslationResponse>( string.Format( "help_center/categories/{0}/translations.json", translation.SourceId ), body );
+			return GenericPost<IndividualTranslationResponse>( string.Format( "help_center/categories/{0}/translations.json", CategoryId ), body );
 		}
 
 		public IndividualTranslationResponse UpdateArticleTranslation( Translation translation )
@@ -109,6 +136,15 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 		public bool DeleteTranslation( long translationId )
 		{
 			return GenericDelete( string.Format( "help_center/translations/{0}.json", translationId ) );
+		}
+
+		public IList<string> ListAllEnabledLocalesAndDefaultLocale( out string defaultLocale )
+		{
+			var res = RunRequest( "help_center/locales.json", "GET" );
+			var anon_type = new { locales = new List<string>(), default_locale = "" };
+			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Content, anon_type );
+			defaultLocale = locale_info.default_locale;
+			return locale_info.locales;
 		}
 
 #endif

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Translations.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Translations.cs
@@ -38,6 +38,30 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 #endif
 
 #if ASYNC
+
+		Task<GroupTranslationResponse> ListTranslationsForArticleAsync( long articleId );
+		Task<GroupTranslationResponse> ListTranslationsForSectionAsync( long articleId );
+		Task<GroupTranslationResponse> ListTranslationsForCategoryAsync( long articleId );
+
+		Task<IList<string>> ListMissingTranslationsForArticleAsync( long articleId );
+		Task<IList<string>> ListMissingTranslationsForSectionAsync( long articleId );
+		Task<IList<string>> ListMissingTranslationsForCategoryAsync( long articleId );
+
+		Task<IndividualTranslationResponse> ShowTranslationForArticleAsync( long articleId, string locale );
+
+		Task<IndividualTranslationResponse> CreateArticleTranslationAsync( long articleId, Translation translation );
+		Task<IndividualTranslationResponse> CreateSectionTranslationAsync( long SectionId, Translation translation );
+		Task<IndividualTranslationResponse> CreateCategoryTranslationAsync( long CategoryId, Translation translation );
+
+		Task<IndividualTranslationResponse> UpdateArticleTranslationAsync( Translation translation );
+		Task<IndividualTranslationResponse> UpdateSectionTranslationAsync( Translation translation );
+		Task<IndividualTranslationResponse> UpdateCategoryTranslationAsync( Translation translation );
+
+		Task<bool> DeleteTranslationAsync( long translationId );
+
+		Task<Tuple<IList<string>, string>> ListAllEnabledLocalesAndDefaultLocaleAsync();
+
+
 #endif
 	}
 
@@ -150,6 +174,104 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 #endif
 
 #if ASYNC
+
+
+		public async Task<GroupTranslationResponse> ListTranslationsForArticleAsync( long articleId )
+		{
+			var resourceUrl = String.Format( "/help_center/articles/{0}/translations.json", articleId );
+
+			return await GenericGetAsync<GroupTranslationResponse>( resourceUrl );
+		}
+
+		public async Task<GroupTranslationResponse> ListTranslationsForSectionAsync( long articleId )
+		{
+			var resourceUrl = String.Format( "/help_center/sections/{0}/translations.json", articleId );
+
+			return await GenericGetAsync<GroupTranslationResponse>( resourceUrl );
+		}
+
+		public async Task<GroupTranslationResponse> ListTranslationsForCategoryAsync( long articleId )
+		{
+			var resourceUrl = String.Format( "/help_center/categories/{0}/translations.json", articleId );
+
+			return await GenericGetAsync<GroupTranslationResponse>( resourceUrl );
+		}
+
+
+		public async Task<IList<string>> ListMissingTranslationsForArticleAsync( long articleId )
+		{
+			var res = RunRequestAsync( String.Format( "help_center/articles/{0}/translations/missing.json", articleId ), "GET" );
+			var anon_type = new { locales = new List<string>() };
+			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Result.Content, anon_type );
+			return locale_info.locales;
+		}
+		public async Task<IList<string>> ListMissingTranslationsForSectionAsync( long articleId )
+		{
+			var res = RunRequestAsync( String.Format( "help_center/sections/{0}/translations/missing.json", articleId ), "GET" );
+			var anon_type = new { locales = new List<string>() };
+			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Result.Content, anon_type );
+			return locale_info.locales;
+		}
+		public async Task<IList<string>> ListMissingTranslationsForCategoryAsync( long articleId )
+		{
+			var res = RunRequestAsync( String.Format( "help_center/categories/{0}/translations/missing.json", articleId ), "GET" );
+			var anon_type = new { locales = new List<string>() };
+			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Result.Content, anon_type );
+			return locale_info.locales;
+		}
+
+		public async Task<IndividualTranslationResponse> ShowTranslationForArticleAsync( long articleId, string locale )
+		{
+			var resourceUrl = String.Format( "/help_center/articles/{0}/translations/{1}.json", articleId, locale );
+			return await GenericGetAsync<IndividualTranslationResponse>( resourceUrl );
+		}
+
+		public async Task<IndividualTranslationResponse> CreateArticleTranslationAsync( long articleId, Translation translation )
+		{
+			var body = new { translation };
+			return await GenericPostAsync<IndividualTranslationResponse>( string.Format( "help_center/articles/{0}/translations.json", articleId ), body );
+		}
+		public async Task<IndividualTranslationResponse> CreateSectionTranslationAsync( long SectionId, Translation translation )
+		{
+			var body = new { translation };
+			return await GenericPostAsync<IndividualTranslationResponse>( string.Format( "help_center/sections/{0}/translations.json", SectionId ), body );
+		}
+		public async Task<IndividualTranslationResponse> CreateCategoryTranslationAsync( long CategoryId, Translation translation )
+		{
+			var body = new { translation };
+			return await GenericPostAsync<IndividualTranslationResponse>( string.Format( "help_center/categories/{0}/translations.json", CategoryId ), body );
+		}
+
+		public async Task<IndividualTranslationResponse> UpdateArticleTranslationAsync( Translation translation )
+		{
+			var body = new { translation };
+			return await GenericPutAsync<IndividualTranslationResponse>( string.Format( "help_center/articles/{0}/translations/{1}.json", translation.SourceId, translation.Locale ), body );
+		}
+
+		public async Task<IndividualTranslationResponse> UpdateSectionTranslationAsync( Translation translation )
+		{
+			var body = new { translation };
+			return await GenericPutAsync<IndividualTranslationResponse>( string.Format( "help_center/sections/{0}/translations/{1}.json", translation.SourceId, translation.Locale ), body );
+		}
+
+		public async Task<IndividualTranslationResponse> UpdateCategoryTranslationAsync( Translation translation )
+		{
+			var body = new { translation };
+			return await GenericPutAsync<IndividualTranslationResponse>( string.Format( "help_center/categories/{0}/translations/{1}.json", translation.SourceId, translation.Locale ), body );
+		}
+
+		public async Task<bool> DeleteTranslationAsync( long translationId )
+		{
+			return await GenericDeleteAsync( string.Format( "help_center/translations/{0}.json", translationId ) );
+		}
+
+		public async Task<Tuple<IList<string>, string>> ListAllEnabledLocalesAndDefaultLocaleAsync( )
+		{
+			var res = await RunRequestAsync( "help_center/locales.json", "GET" );
+			var anon_type = new { locales = new List<string>(), default_locale = "" };
+			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Content, anon_type );
+			return new Tuple<IList<string>, string>( locale_info.locales, locale_info.default_locale );
+		}
 #endif
 
 

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Translations.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Translations.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+#if ASYNC
+using System.Threading.Tasks;
+#endif
+using ZendeskApi_v2.Models.Sections;
+using ZendeskApi_v2.Models.HelpCenter.Translations;
+
+namespace ZendeskApi_v2.Requests.HelpCenter
+{
+	public interface ITranslations : ICore
+	{
+#if SYNC
+
+		IList<string> ListMissingTranslationsForArticle( long articleId );
+		IList<string> ListMissingTranslationsForSection( long articleId );
+		IList<string> ListMissingTranslationsForCategory( long articleId );
+		IList<string> ListAllEnabledLocalesAndDefaultLocale( out string defaultLocale );
+
+
+		IndividualTranslationResponse CreateArticleTranslation( long articleId, Translation translation );
+		IndividualTranslationResponse CreateSectionTranslation( long SectionId, Translation translation );
+		IndividualTranslationResponse CreateCategoryTranslation( long CategoryId, Translation translation );
+
+		IndividualTranslationResponse UpdateArticleTranslation( Translation translation );
+		IndividualTranslationResponse UpdateSectionTranslation( Translation translation );
+		IndividualTranslationResponse UpdateCategoryTranslation( Translation translation );
+
+		bool DeleteTranslation( long translationId );
+#endif
+
+#if ASYNC
+#endif
+	}
+
+	public class Translations : Core, ITranslations
+	{
+		public Translations( string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken )
+			: base( yourZendeskUrl, user, password, apiToken, p_OAuthToken )
+		{
+		}
+
+#if SYNC
+		public IList<string> ListMissingTranslationsForArticle( long articleId )
+		{
+			var res = RunRequest( String.Format( "help_center/articles/{0}/translations/missing.json", articleId ), "GET" );
+			var anon_type = new { locales = new List<string>() };
+			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Content, anon_type );
+			return anon_type.locales;
+		}
+		public IList<string> ListMissingTranslationsForSection( long articleId )
+		{
+			var res = RunRequest( String.Format( "help_center/sections/{0}/translations/missing.json", articleId ), "GET" );
+			var anon_type = new { locales = new List<string>() };
+			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Content, anon_type );
+			return anon_type.locales;
+		}
+		public IList<string> ListMissingTranslationsForCategory( long articleId )
+		{
+			var res = RunRequest( String.Format( "help_center/categories/{0}/translations/missing.json", articleId ), "GET" );
+			var anon_type = new { locales = new List<string>() };
+			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Content, anon_type );
+			return anon_type.locales;
+		}
+		public IList<string> ListAllEnabledLocalesAndDefaultLocale( out string defaultLocale )
+		{
+			var res = RunRequest( "help_center/locales.json", "GET" );
+			var anon_type = new { locales = new List<string>(), default_locale = "" };
+			var locale_info = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType( res.Content, anon_type );
+			defaultLocale = locale_info.default_locale;
+			return locale_info.locales;
+		}
+		public IndividualTranslationResponse CreateArticleTranslation( long articleId, Translation translation )
+		{
+			var body = new { translation };
+			return GenericPost<IndividualTranslationResponse>( string.Format( "help_center/articles/{0}/translations.json", translation.SourceId ), body );
+		}
+		public IndividualTranslationResponse CreateSectionTranslation( long SectionId, Translation translation )
+		{
+			var body = new { translation };
+			return GenericPost<IndividualTranslationResponse>( string.Format( "help_center/sections/{0}/translations.json", translation.SourceId ), body );
+		}
+		public IndividualTranslationResponse CreateCategoryTranslation( long CategoryId, Translation translation )
+		{
+			var body = new { translation };
+			return GenericPost<IndividualTranslationResponse>( string.Format( "help_center/categories/{0}/translations.json", translation.SourceId ), body );
+		}
+
+		public IndividualTranslationResponse UpdateArticleTranslation( Translation translation )
+		{
+			var body = new { translation };
+			return GenericPut<IndividualTranslationResponse>( string.Format( "help_center/articles/{0}/translations/{1}.json", translation.SourceId, translation.Locale ), body );
+		}
+
+		public IndividualTranslationResponse UpdateSectionTranslation( Translation translation )
+		{
+			var body = new { translation };
+			return GenericPut<IndividualTranslationResponse>( string.Format( "help_center/sections/{0}/translations/{1}.json", translation.SourceId, translation.Locale ), body );
+		}
+
+		public IndividualTranslationResponse UpdateCategoryTranslation( Translation translation )
+		{
+			var body = new { translation };
+			return GenericPut<IndividualTranslationResponse>( string.Format( "help_center/categories/{0}/translations/{1}.json", translation.SourceId, translation.Locale ), body );
+		}
+
+		public bool DeleteTranslation( long translationId )
+		{
+			return GenericDelete( string.Format( "help_center/translations/{0}.json", translationId ) );
+		}
+
+#endif
+
+#if ASYNC
+#endif
+
+
+	}
+}

--- a/src/ZendeskApi_v2/ZendeskApi_v2.csproj
+++ b/src/ZendeskApi_v2/ZendeskApi_v2.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Models\Constants\UserRoles.cs" />
     <Compile Include="Models\Constants\ViaTypes.cs" />
     <Compile Include="Models\Constants\Visibility.cs" />
+    <Compile Include="Models\HelpCenter\Translations\GroupTranslationResponse.cs" />
     <Compile Include="Models\HelpCenter\Translations\IndividualTranslationResponse.cs" />
     <Compile Include="Models\IndividualResponseBase.cs" />
     <Compile Include="Models\CustomRoles\Configuration.cs" />

--- a/src/ZendeskApi_v2/ZendeskApi_v2.csproj
+++ b/src/ZendeskApi_v2/ZendeskApi_v2.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Models\Constants\UserRoles.cs" />
     <Compile Include="Models\Constants\ViaTypes.cs" />
     <Compile Include="Models\Constants\Visibility.cs" />
+    <Compile Include="Models\HelpCenter\Translations\IndividualTranslationResponse.cs" />
     <Compile Include="Models\IndividualResponseBase.cs" />
     <Compile Include="Models\CustomRoles\Configuration.cs" />
     <Compile Include="Models\CustomRoles\CustomRole.cs" />
@@ -278,6 +279,7 @@
     <Compile Include="Requests\HelpCenter\ArticleSortingOptions.cs" />
     <Compile Include="Requests\HelpCenter\Categories.cs" />
     <Compile Include="Requests\HelpCenter\Comments.cs" />
+    <Compile Include="Requests\HelpCenter\Translations.cs" />
     <Compile Include="Requests\HelpCenter\Votes.cs" />
     <Compile Include="Requests\JobStatuses.cs" />
     <Compile Include="Requests\Locales.cs" />

--- a/src/ZendeskApi_v2_Mobile/ZendeskApi_v2_Mobile.csproj
+++ b/src/ZendeskApi_v2_Mobile/ZendeskApi_v2_Mobile.csproj
@@ -222,6 +222,12 @@
     <Compile Include="..\ZendeskApi_v2\Models\HelpCenter\Comments\IndividualCommentResponse.cs">
       <Link>Models\HelpCenter\Comments\IndividualCommentResponse.cs</Link>
     </Compile>
+    <Compile Include="..\ZendeskApi_v2\Models\HelpCenter\Translations\GroupTranslationResponse.cs">
+      <Link>Models\HelpCenter\Translations\GroupTranslationResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\ZendeskApi_v2\Models\HelpCenter\Translations\IndividualTranslationResponse.cs">
+      <Link>Models\HelpCenter\Translations\IndividualTranslationResponse.cs</Link>
+    </Compile>
     <Compile Include="..\ZendeskApi_v2\Models\HelpCenter\Translations\Translation.cs">
       <Link>Models\HelpCenter\Translations\Translation.cs</Link>
     </Compile>
@@ -741,6 +747,9 @@
     <Compile Include="..\ZendeskApi_v2\Requests\HelpCenter\Sections.cs">
       <Link>Requests\HelpCenter\Sections.cs</Link>
     </Compile>
+    <Compile Include="..\ZendeskApi_v2\Requests\HelpCenter\Translations.cs">
+      <Link>Requests\HelpCenter\Translations.cs</Link>
+    </Compile>
     <Compile Include="..\ZendeskApi_v2\Requests\HelpCenter\Votes.cs">
       <Link>Requests\HelpCenter\Votes.cs</Link>
     </Compile>
@@ -843,9 +852,7 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Models\HelpCenter\NewFolder1\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <PropertyGroup>

--- a/src/ZendeskApi_v2_Net35/ZendeskApi_v2_Net35.csproj
+++ b/src/ZendeskApi_v2_Net35/ZendeskApi_v2_Net35.csproj
@@ -226,6 +226,12 @@
     <Compile Include="..\ZendeskApi_v2\Models\HelpCenter\Comments\IndividualCommentResponse.cs">
       <Link>Models\HelpCenter\Comments\IndividualCommentResponse.cs</Link>
     </Compile>
+    <Compile Include="..\ZendeskApi_v2\Models\HelpCenter\Translations\GroupTranslationResponse.cs">
+      <Link>Models\HelpCenter\Translations\GroupTranslationResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\ZendeskApi_v2\Models\HelpCenter\Translations\IndividualTranslationResponse.cs">
+      <Link>Models\HelpCenter\Translations\IndividualTranslationResponse.cs</Link>
+    </Compile>
     <Compile Include="..\ZendeskApi_v2\Models\HelpCenter\Translations\Translation.cs">
       <Link>Models\HelpCenter\Translations\Translation.cs</Link>
     </Compile>
@@ -744,6 +750,9 @@
     </Compile>
     <Compile Include="..\ZendeskApi_v2\Requests\HelpCenter\Sections.cs">
       <Link>Requests\HelpCenter\Sections.cs</Link>
+    </Compile>
+    <Compile Include="..\ZendeskApi_v2\Requests\HelpCenter\Translations.cs">
+      <Link>Requests\HelpCenter\Translations.cs</Link>
     </Compile>
     <Compile Include="..\ZendeskApi_v2\Requests\HelpCenter\Votes.cs">
       <Link>Requests\HelpCenter\Votes.cs</Link>


### PR DESCRIPTION
Please accept the other pull request before this one.  (one of the tests from this branch will fail until the other pull request is accepted)

This pull request adds support for help center translations.

It also adds the ability to side load translations when loading an article.

It includes a set of unit tests to test all of the new translation functions. (one test will fail until the other pr is merged in)

It includes two unit tests to test the side-loading of translations with articles.

In the process of creating this, I enabled the French Locale on the help center of the testing ZenDesk account.