### PR TITLE
updated SearchForOrganizations to better reflect its purpose

### DIFF
--- a/src/Tests/OrganizationTests.cs
+++ b/src/Tests/OrganizationTests.cs
@@ -67,8 +67,8 @@ namespace Tests
             var res = api.Organizations.GetOrganizationsStartingWith(Settings.DefaultOrg.Substring(0, 3));
             Assert.Greater(res.Count, 0);
 
-            var search = api.Organizations.SearchForOrganizations(Settings.DefaultOrg);
-            Assert.Greater(res.Count, 0);
+            var search = api.Organizations.SearchForOrganizationsByExternalId(Settings.DefaultExternalId);
+            Assert.Greater(search.Count, 0);
         }
 
         [Test]

--- a/src/Tests/Settings.cs
+++ b/src/Tests/Settings.cs
@@ -4,7 +4,7 @@
 
         public const string Site = "https://csharpapi.zendesk.com/api/v2/";
         public const string DefaultOrg = "csharpapi";
-        public const string DefaultExternalId = "abcd123";
+        public const string DefaultExternalId = "1234abc";
 
         public const string Email = "eric.neifert@gmail.com";
         public const string Password = "pa55word";

--- a/src/Tests/Settings.cs
+++ b/src/Tests/Settings.cs
@@ -4,6 +4,8 @@
 
         public const string Site = "https://csharpapi.zendesk.com/api/v2/";
         public const string DefaultOrg = "csharpapi";
+        public const string DefaultExternalId = "abcd123";
+
         public const string Email = "eric.neifert@gmail.com";
         public const string Password = "pa55word";
         public const string ApiToken = "R5PXRh5hEwT9Ry3hfSzGF2WKsxPf3ScSCq0suxii";

--- a/src/ZendeskApi_v2/Requests/Organizations.cs
+++ b/src/ZendeskApi_v2/Requests/Organizations.cs
@@ -20,7 +20,7 @@ namespace ZendeskApi_v2.Requests
         /// <returns></returns>
         GroupOrganizationResponse GetOrganizationsStartingWith(string name);
 
-        GroupOrganizationResponse SearchForOrganizations(string searchTerm);
+        GroupOrganizationResponse SearchForOrganizationsByExternalId(string externalId);
         IndividualOrganizationResponse GetOrganization(long id);
         IndividualOrganizationResponse CreateOrganization(Organization organization);
         IndividualOrganizationResponse UpdateOrganization(Organization organization);
@@ -94,9 +94,9 @@ namespace ZendeskApi_v2.Requests
             return GenericPost<GroupOrganizationResponse>(string.Format("organizations/autocomplete.json?name={0}", name));
         }
 
-        public GroupOrganizationResponse SearchForOrganizations(string searchTerm)
+        public GroupOrganizationResponse SearchForOrganizationsByExternalId(string externalId)
         {
-            return GenericGet<GroupOrganizationResponse>(string.Format("organizations/search.json?external_id={0}", searchTerm));
+            return GenericGet<GroupOrganizationResponse>(string.Format("organizations/search.json?external_id={0}", externalId));
         }
 
         public IndividualOrganizationResponse GetOrganization(long id)


### PR DESCRIPTION
- updated SearchForOrganizations to better reflect that it's searching by ExternalId
- updated tests to actually look at externalId results
- added DefaultExternalId setting for test

It was previously confusing to know how the search was being performed based on the method signature.  This should clarify usage from a client perspective.

