### PR TITLE
Included original Response in new WebException

### DIFF
--- a/src/ZendeskApi_v2/Core.cs
+++ b/src/ZendeskApi_v2/Core.cs
@@ -564,9 +564,8 @@ namespace ZendeskApi_v2
                 headersMessage += originalWebException.Response.Headers;
             }
 
-            var wException = new WebException(originalWebException.Message + headersMessage, originalWebException);
+            var wException = new WebException(originalWebException.Message + headersMessage, originalWebException, originalWebException.Status, originalWebException.Response);
             wException.Data.Add("jsonException", error);
-			wException.Response = originalWebException.Response;
 
             return wException;
         }

--- a/src/ZendeskApi_v2/Core.cs
+++ b/src/ZendeskApi_v2/Core.cs
@@ -566,6 +566,7 @@ namespace ZendeskApi_v2
 
             var wException = new WebException(originalWebException.Message + headersMessage, originalWebException);
             wException.Data.Add("jsonException", error);
+			wException.Response = originalWebException.Response;
 
             return wException;
         }


### PR DESCRIPTION
Original WebException response is now included when wrapped into a new WebException.
