### PR TITLE
remove Microsoft.Net.Http dependency for .net4.5

### DIFF
--- a/src/ZendeskApi_v2/ZendeskApi_v2.csproj
+++ b/src/ZendeskApi_v2/ZendeskApi_v2.csproj
@@ -83,7 +83,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'uap10.0'">
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="5.4.1" />


### PR DESCRIPTION
as far as I know there is no need to have dependency on Microsoft.Net.Http package for .net4.5

which would remove dependencies for 
- Microsoft.Bcl (>= 1.1.10)
- Microsoft.Bcl.Async (>= 1.0.168)

for .net4.5 framework which are installed as part of Microsoft.Net.Http when you install latest package in project (even so this package does not require Bcl packages for net4.5)