### PR TITLE
Test "CanCreateTicketWithDueDate" can't run on PCs that use dd/MM/yyyy format

### DIFF
--- a/test/ZendeskApi_v2.Test/TicketTests.cs
+++ b/test/ZendeskApi_v2.Test/TicketTests.cs
@@ -532,7 +532,7 @@ namespace Tests
         public void CanCreateTicketWithDueDate()
         {
             //31 December 2020 2AM
-            var dueAt = DateTimeOffset.Parse("12/31/2020 07:00:00 -05:00");
+            var dueAt = DateTimeOffset.Parse("12/31/2020 07:00:00 -05:00", CultureInfo.InvariantCulture);
 
             var ticket = new Ticket()
             {


### PR DESCRIPTION
I'm running the code on a PC that uses the European style date format (dd/MM/yyyy)

This test assumes that the machine uses MM/dd/yyyy format as the code does not specify a culture. By providing Invariant Culture To the Parse Method you are ensured that code will work no matter what format the PC it is run on have.