### PR TITLE
Changed Body property in Event Model from string to object to support…

### DIFF
--- a/src/ZendeskApi_v2/Models/Shared/Event.cs
+++ b/src/ZendeskApi_v2/Models/Shared/Event.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace ZendeskApi_v2.Models.Shared
@@ -12,7 +12,7 @@ namespace ZendeskApi_v2.Models.Shared
         public string Type { get; set; }
 
         [JsonProperty("body")]
-        public string Body { get; set; }
+        public object Body { get; set; }
 
         [JsonProperty("public")]
         public bool Public { get; set; }        

--- a/src/ZendeskApi_v2/Models/Shared/Event.cs
+++ b/src/ZendeskApi_v2/Models/Shared/Event.cs
@@ -12,7 +12,7 @@ namespace ZendeskApi_v2.Models.Shared
         public string Type { get; set; }
 
         [JsonProperty("body")]
-        public object Body { get; set; }
+        public dynamic Body { get; set; }
 
         [JsonProperty("public")]
         public bool Public { get; set; }        


### PR DESCRIPTION
… Zendesk Answer bot (EventType: Automatic AnswerSend) (that does not only contain a string but an array).

NB: This is a breaking change for people who use this property as string (call .ToString() to fix)