### PR TITLE
Adding Support for External Content API

### DIFF
--- a/src/ZendeskApi_v2/FederatedSearchApi.cs
+++ b/src/ZendeskApi_v2/FederatedSearchApi.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using ZendeskApi_v2.Requests.FederatedSearch;
+
+namespace ZendeskApi_v2.FederatedSearch
+{
+    public interface IFederatedSearchApi
+    {
+        IExternalContentRecords ExternalContentRecords { get; }
+        IExternalContentSources ExternalContentSources { get; }
+        IExternalContentTypes ExternalContentTypes { get; }
+        string Locale { get; }
+    }
+
+    public class FederatedSearchApi : IFederatedSearchApi
+    {
+        public FederatedSearchApi(
+            string yourZendeskUrl,
+            string user,
+            string password,
+            string apiToken,
+            string locale,
+            string p_OAuthToken,
+            Dictionary<string, string> customHeaders)
+        {
+            ExternalContentRecords = new ExternalContentRecords(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaders);
+            ExternalContentSources = new ExternalContentSources(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaders);
+            ExternalContentTypes = new ExternalContentTypes(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaders);
+            Locale = locale;
+        }
+
+        public IExternalContentRecords ExternalContentRecords { get; }
+        public IExternalContentSources ExternalContentSources { get; }
+        public IExternalContentTypes ExternalContentTypes { get; }
+        public string Locale { get; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/ExternalContentBase.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/ExternalContentBase.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using ZendeskApi_v2.Extensions;
+using ZendeskApi_v2.Models.FederatedSearch;
+
+namespace ZendeskApi_v2.Models.FederatedSearch
+{
+    public interface IExternalContentBase
+    {
+        string Id { get; set; }
+        DateTimeOffset? CreatedAt { get; set; }
+
+        DateTimeOffset? UpdatedAt { get; set; }
+    }
+
+    public class ExternalContentBase : IExternalContentBase
+    {
+        [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [JsonProperty("created_at", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
+
+        [JsonProperty("updated_at", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/ExternalContentRecord.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/ExternalContentRecord.cs
@@ -1,0 +1,80 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+using ZendeskApi_v2.Models.HelpCenter.Translations;
+
+namespace ZendeskApi_v2.Models.FederatedSearch
+{
+    public class ExternalContentRecord
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("locale")]
+        public string Locale { get; set; }
+
+        [JsonProperty("body")]
+        public string Body { get; set; }
+
+        [JsonProperty("external_id")]
+        public string ExternalId { get; set; }
+
+        [JsonProperty("user_segment_id", NullValueHandling = NullValueHandling.Include,
+            DefaultValueHandling = DefaultValueHandling.Include )]
+        public string UserSegmentId { get; set; }        
+
+        [JsonProperty("source")]
+        public ExternalContentSource Source { get; set; }
+
+        [JsonProperty("type")]
+        public ExternalContentType Type { get; set; }
+
+        [JsonProperty("created_at", NullValueHandling = NullValueHandling.Include)]
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        [JsonProperty("updated_at", NullValueHandling = NullValueHandling.Include)]
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset UpdatedAt { get; set; }
+    }
+    //New class for create/update operations since the Source/Type structures are only required for GET operations
+    public class CreateUpdateExternalContentRecord
+    {
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("locale")]
+        public string Locale { get; set; }
+
+        [JsonProperty("body")]
+        public string Body { get; set; }
+
+        [JsonProperty("external_id")]
+        public string ExternalId { get; set; }
+
+        [JsonProperty("user_segment_id", NullValueHandling = NullValueHandling.Include,
+            DefaultValueHandling = DefaultValueHandling.Include )]
+        public string UserSegmentId { get; set; }        
+
+        [JsonProperty("source_id")]
+        public string SourceId { get; set; }
+
+        [JsonProperty("type_id")]
+        public string TypeId { get; set; }
+    }
+
+    public class ExternalContentRecordRequest {
+          [JsonProperty("record")]
+          public CreateUpdateExternalContentRecord Record { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/ExternalContentSource.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/ExternalContentSource.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+
+namespace ZendeskApi_v2.Models.FederatedSearch
+{
+    public class ExternalContentSource : ExternalContentBase
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+
+    public class ExternalContentSourceRequest {
+        [JsonProperty("source")]
+        public ExternalContentSource Source { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/ExternalContentType.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/ExternalContentType.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+
+namespace ZendeskApi_v2.Models.FederatedSearch
+{
+    public class ExternalContentType : ExternalContentBase
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+
+    public class ExternalContentTypeRequest {
+        [JsonProperty("type")]
+        public ExternalContentType Type { get; set; }    
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentRecordsResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentRecordsResponse.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using ZendeskApi_v2.Models.FederatedSearch;
 
@@ -6,7 +6,6 @@ namespace ZendeskApi_v2.Models.FederatedSearch
 {
     public class GroupExternalContentRecordsResponse : GroupExternalContentResponseBase
     {
-
         [JsonProperty("records")]
         public IList<ExternalContentRecord> Records { get; set; }
     }

--- a/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentRecordsResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentRecordsResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using ZendeskApi_v2.Models.FederatedSearch;
+
+namespace ZendeskApi_v2.Models.FederatedSearch
+{
+    public class GroupExternalContentRecordsResponse : GroupExternalContentResponseBase
+    {
+
+        [JsonProperty("records")]
+        public IList<ExternalContentRecord> Records { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentResponseBase.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentResponseBase.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using ZendeskApi_v2.Extensions;
+using ZendeskApi_v2.Models.FederatedSearch;
+
+namespace ZendeskApi_v2.Models.FederatedSearch
+{
+    public interface IGroupExternalContentResponseBase
+    {
+        GroupExternalContentResponseMeta Meta {get;set;}
+    }
+
+    public interface IExternalContentMetaResponseBase
+    {
+        [JsonProperty("has_more")]
+        bool HasMore {get;set;}
+        [JsonProperty("after_cursor")]
+        string AfterCursor{ get; set;}
+        [JsonProperty("before_cursor")]
+        string BeforeCursor {get; set;}
+    }
+
+    public class GroupExternalContentResponseBase : IGroupExternalContentResponseBase
+    {
+        [JsonProperty("meta")]
+        public GroupExternalContentResponseMeta Meta {get;set;}
+    }
+
+    public class GroupExternalContentResponseMeta : IExternalContentMetaResponseBase
+    {
+        [JsonProperty("has_more")]
+        public bool HasMore { get ; set ; }
+        [JsonProperty("after_cursor")]
+        public string AfterCursor { get; set; }
+        [JsonProperty("before_cursor")]
+        public string BeforeCursor { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentSourcesResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentSourcesResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using ZendeskApi_v2.Models.FederatedSearch;
+
+namespace ZendeskApi_v2.Models.FederatedSearch
+{
+    public class GroupExternalContentSourcesResponse : GroupExternalContentResponseBase
+    {
+
+        [JsonProperty("Sources")]
+        public IList<ExternalContentSource> Sources { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentSourcesResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentSourcesResponse.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using ZendeskApi_v2.Models.FederatedSearch;
 
@@ -6,7 +6,6 @@ namespace ZendeskApi_v2.Models.FederatedSearch
 {
     public class GroupExternalContentSourcesResponse : GroupExternalContentResponseBase
     {
-
         [JsonProperty("Sources")]
         public IList<ExternalContentSource> Sources { get; set; }
     }

--- a/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentTypesResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentTypesResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using ZendeskApi_v2.Models.FederatedSearch;
+
+namespace ZendeskApi_v2.Models.FederatedSearch
+{
+    public class GroupExternalContentTypesResponse : GroupExternalContentResponseBase
+    {
+
+        [JsonProperty("types")]
+        public IList<ExternalContentType> Types { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentTypesResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/GroupExternalContentTypesResponse.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using ZendeskApi_v2.Models.FederatedSearch;
 
@@ -6,7 +6,6 @@ namespace ZendeskApi_v2.Models.FederatedSearch
 {
     public class GroupExternalContentTypesResponse : GroupExternalContentResponseBase
     {
-
         [JsonProperty("types")]
         public IList<ExternalContentType> Types { get; set; }
     }

--- a/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentRecordResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentRecordResponse.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using ZendeskApi_v2.Models.FederatedSearch;
 
@@ -6,7 +6,6 @@ namespace ZendeskApi_v2.Models.FederatedSearch
 {
     public class IndividualExternalContentRecordResponse
     {
-
         [JsonProperty("record")]
         public ExternalContentRecord Record { get; set; }
     }

--- a/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentRecordResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentRecordResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using ZendeskApi_v2.Models.FederatedSearch;
+
+namespace ZendeskApi_v2.Models.FederatedSearch
+{
+    public class IndividualExternalContentRecordResponse
+    {
+
+        [JsonProperty("record")]
+        public ExternalContentRecord Record { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentSourceResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentSourceResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using ZendeskApi_v2.Models.FederatedSearch;
+
+namespace ZendeskApi_v2.Models.FederatedSearch
+{
+    public class IndividualExternalContentSourceResponse
+    {
+
+        [JsonProperty("source")]
+        public ExternalContentSource Source { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentSourceResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentSourceResponse.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using ZendeskApi_v2.Models.FederatedSearch;
 
@@ -6,7 +6,6 @@ namespace ZendeskApi_v2.Models.FederatedSearch
 {
     public class IndividualExternalContentSourceResponse
     {
-
         [JsonProperty("source")]
         public ExternalContentSource Source { get; set; }
     }

--- a/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentTypeResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentTypeResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using ZendeskApi_v2.Models.FederatedSearch;
+
+namespace ZendeskApi_v2.Models.FederatedSearch
+{
+    public class IndividualExternalContentTypeResponse
+    {
+
+        [JsonProperty("type")]
+        public ExternalContentType Type { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentTypeResponse.cs
+++ b/src/ZendeskApi_v2/Models/FederatedSearch/IndividualExternalContentTypeResponse.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using ZendeskApi_v2.Models.FederatedSearch;
 
@@ -6,7 +6,6 @@ namespace ZendeskApi_v2.Models.FederatedSearch
 {
     public class IndividualExternalContentTypeResponse
     {
-
         [JsonProperty("type")]
         public ExternalContentType Type { get; set; }
     }

--- a/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentRecord.cs
+++ b/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentRecord.cs
@@ -50,21 +50,17 @@ namespace ZendeskApi_v2.Requests.FederatedSearch
         public IndividualExternalContentRecordResponse ShowExternalContentRecord(string externalRecordId)
         {
             var resourceUrl = $"{urlPrefix}/records/{externalRecordId}";
-
             return GenericGet<IndividualExternalContentRecordResponse>(resourceUrl);
         }
         public GroupExternalContentRecordsResponse ListExternalContentRecords(string after=null, string before=null, int? size=null)
         {
             var resourceUrl = $"{urlPrefix}/records?" + BuildExternalContentQueryString(after,before,size);
-
             return GenericGet<GroupExternalContentRecordsResponse>(resourceUrl);
-
         }
 
         public IndividualExternalContentRecordResponse CreateExternalContentRecord(ExternalContentRecordRequest externalContentRecord)
         {
             var resourceUrl = $"{urlPrefix}/records";
-
             return GenericPost<IndividualExternalContentRecordResponse>(resourceUrl,externalContentRecord);
         }
 
@@ -84,7 +80,6 @@ namespace ZendeskApi_v2.Requests.FederatedSearch
         public async Task<IndividualExternalContentRecordResponse> ShowExternalContentRecordAsync(string externalRecordId)
         {
             var resourceUrl = $"{urlPrefix}/records/{externalRecordId}";
-
             return await GenericGetAsync<IndividualExternalContentRecordResponse>(resourceUrl);
         }
 
@@ -93,13 +88,11 @@ namespace ZendeskApi_v2.Requests.FederatedSearch
             var resourceUrl = $"{urlPrefix}/records?" + BuildExternalContentQueryString(after,before,size);
 
             return await GenericGetAsync<GroupExternalContentRecordsResponse>(resourceUrl);
-
         }
 
         public async Task<IndividualExternalContentRecordResponse> CreateExternalContentRecordAsync(ExternalContentRecordRequest externalContentRecord)
         {
             var resourceUrl = $"{urlPrefix}/records";
-            
             return await GenericPostAsync<IndividualExternalContentRecordResponse>(resourceUrl,externalContentRecord);
         }
 

--- a/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentRecord.cs
+++ b/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentRecord.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+#if ASYNC
+
+using System.Threading.Tasks;
+
+#endif
+
+using ZendeskApi_v2.Extensions;
+using ZendeskApi_v2.Models.FederatedSearch;
+
+namespace ZendeskApi_v2.Requests.FederatedSearch
+{
+    public interface IExternalContentRecords : ICore
+    {
+#if SYNC
+        IndividualExternalContentRecordResponse ShowExternalContentRecord(string externalRecordId);
+        GroupExternalContentRecordsResponse ListExternalContentRecords(string after = null, string before = null, int? size = null);
+        IndividualExternalContentRecordResponse CreateExternalContentRecord(ExternalContentRecordRequest externalContentRecord);
+
+        IndividualExternalContentRecordResponse UpdateExternalContentRecord(string externalRecordId, ExternalContentRecordRequest externalContentRecord);
+        bool? DeleteExternalContentRecord(string externalRecordId);
+#endif
+#if ASYNC   
+        Task<IndividualExternalContentRecordResponse> ShowExternalContentRecordAsync(string externalRecordId);
+        Task<GroupExternalContentRecordsResponse> ListExternalContentRecordsAsync(string after = null, string before = null, int? size = null);     
+        Task<IndividualExternalContentRecordResponse> CreateExternalContentRecordAsync(ExternalContentRecordRequest externalContentRecord);
+        Task<IndividualExternalContentRecordResponse> UpdateExternalContentRecordAsync(string externalRecordId, ExternalContentRecordRequest externalContentRecord);
+        Task<bool?> DeleteExternalContentRecordAsync(string externalRecordId);
+#endif
+
+    }
+
+    public class ExternalContentRecords: Core, IExternalContentRecords
+    {
+        private readonly string urlPrefix = "guide/external_content";
+
+        public ExternalContentRecords(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
+        {
+            if (!locale.IsNullOrWhiteSpace())
+            {
+                urlPrefix = $"{urlPrefix}";
+            }
+        }
+#if SYNC
+        public IndividualExternalContentRecordResponse ShowExternalContentRecord(string externalRecordId)
+        {
+            var resourceUrl = $"{urlPrefix}/records/{externalRecordId}";
+
+            return GenericGet<IndividualExternalContentRecordResponse>(resourceUrl);
+        }
+        public GroupExternalContentRecordsResponse ListExternalContentRecords(string after=null, string before=null, int? size=null)
+        {
+            var resourceUrl = $"{urlPrefix}/records?" + BuildExternalContentQueryString(after,before,size);
+
+            return GenericGet<GroupExternalContentRecordsResponse>(resourceUrl);
+
+        }
+
+        public IndividualExternalContentRecordResponse CreateExternalContentRecord(ExternalContentRecordRequest externalContentRecord)
+        {
+            var resourceUrl = $"{urlPrefix}/records";
+
+            return GenericPost<IndividualExternalContentRecordResponse>(resourceUrl,externalContentRecord);
+        }
+
+        public IndividualExternalContentRecordResponse UpdateExternalContentRecord(string externalRecordId, ExternalContentRecordRequest externalContentRecord)
+        {
+            var resourceUrl = $"{urlPrefix}/records/{externalRecordId}";
+            return GenericPut<IndividualExternalContentRecordResponse>(resourceUrl, externalContentRecord);
+        }
+        public bool? DeleteExternalContentRecord(string externalRecordId)
+        {
+            var resourceUrl = $"{urlPrefix}/records/{externalRecordId}";
+            return GenericDelete<bool?>(resourceUrl);
+        }
+#endif
+
+#if ASYNC
+        public async Task<IndividualExternalContentRecordResponse> ShowExternalContentRecordAsync(string externalRecordId)
+        {
+            var resourceUrl = $"{urlPrefix}/records/{externalRecordId}";
+
+            return await GenericGetAsync<IndividualExternalContentRecordResponse>(resourceUrl);
+        }
+
+        public async Task<GroupExternalContentRecordsResponse> ListExternalContentRecordsAsync(string after=null, string before=null, int? size=null)
+        {
+            var resourceUrl = $"{urlPrefix}/records?" + BuildExternalContentQueryString(after,before,size);
+
+            return await GenericGetAsync<GroupExternalContentRecordsResponse>(resourceUrl);
+
+        }
+
+        public async Task<IndividualExternalContentRecordResponse> CreateExternalContentRecordAsync(ExternalContentRecordRequest externalContentRecord)
+        {
+            var resourceUrl = $"{urlPrefix}/records";
+            
+            return await GenericPostAsync<IndividualExternalContentRecordResponse>(resourceUrl,externalContentRecord);
+        }
+
+        public async Task<IndividualExternalContentRecordResponse> UpdateExternalContentRecordAsync(string externalRecordId, ExternalContentRecordRequest externalContentRecord)
+        {
+            var resourceUrl = $"{urlPrefix}/records/{externalRecordId}";
+            return await GenericPutAsync<IndividualExternalContentRecordResponse>(resourceUrl, externalContentRecord);
+        }
+        public async Task<bool?> DeleteExternalContentRecordAsync(string externalRecordId)
+        {
+            var resourceUrl = $"{urlPrefix}/records/{externalRecordId}";
+            return await GenericDeleteAsync<bool?>(resourceUrl);
+        }
+#endif
+        private string BuildExternalContentQueryString(string after=null, string before=null, int? size=null)
+        {
+            var queryParams = new Dictionary<string, string>()
+            {
+                {"after",after},
+                {"before",before},
+                {"size",size.ToString()}
+            };
+            return queryParams.GetQueryString();
+        }
+    }
+}

--- a/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentSource.cs
+++ b/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentSource.cs
@@ -31,7 +31,6 @@ namespace ZendeskApi_v2.Requests.FederatedSearch
         Task<IndividualExternalContentSourceResponse> UpdateExternalContentSourceAsync(string externalSourceId, ExternalContentSource externalContentSource);
         Task<bool?> DeleteExternalContentSourceAsync(string externalSourceId);
 #endif
-
     }
 
     public class ExternalContentSources: Core, IExternalContentSources
@@ -50,21 +49,17 @@ namespace ZendeskApi_v2.Requests.FederatedSearch
         public IndividualExternalContentSourceResponse ShowExternalContentSource(string externalSourceId)
         {
             var resourceUrl = $"{urlPrefix}/sources/{externalSourceId}";
-
             return GenericGet<IndividualExternalContentSourceResponse>(resourceUrl);
         }
         public GroupExternalContentSourcesResponse ListExternalContentSources(string after=null, string before=null, int? size=null)
         {
             var resourceUrl = $"{urlPrefix}/sources?" + BuildExternalContentQueryString(after,before,size);
-
             return GenericGet<GroupExternalContentSourcesResponse>(resourceUrl);
-
         }
 
         public IndividualExternalContentSourceResponse CreateExternalContentSource(ExternalContentSourceRequest externalContentSource)
         {
             var resourceUrl = $"{urlPrefix}/sources";
-
             return GenericPost<IndividualExternalContentSourceResponse>(resourceUrl,externalContentSource);
         }
 
@@ -84,22 +79,18 @@ namespace ZendeskApi_v2.Requests.FederatedSearch
         public async Task<IndividualExternalContentSourceResponse> ShowExternalContentSourceAsync(string externalSourceId)
         {
             var resourceUrl = $"{urlPrefix}/sources/{externalSourceId}";
-
             return await GenericGetAsync<IndividualExternalContentSourceResponse>(resourceUrl);
         }
 
         public async Task<GroupExternalContentSourcesResponse> ListExternalContentSourcesAsync(string after=null, string before=null, int? size=null)
         {
             var resourceUrl = $"{urlPrefix}/sources?" + BuildExternalContentQueryString(after,before,size);
-
             return await GenericGetAsync<GroupExternalContentSourcesResponse>(resourceUrl);
-
         }
 
         public async Task<IndividualExternalContentSourceResponse> CreateExternalContentSourceAync(ExternalContentSourceRequest externalContentSource)
         {
             var resourceUrl = $"{urlPrefix}/sources";
-            
             return await GenericPostAsync<IndividualExternalContentSourceResponse>(resourceUrl,externalContentSource);
         }
 

--- a/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentSource.cs
+++ b/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentSource.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+#if ASYNC
+
+using System.Threading.Tasks;
+
+#endif
+
+using ZendeskApi_v2.Extensions;
+using ZendeskApi_v2.Models.FederatedSearch;
+
+namespace ZendeskApi_v2.Requests.FederatedSearch
+{
+    public interface IExternalContentSources : ICore
+    {
+#if SYNC
+        IndividualExternalContentSourceResponse ShowExternalContentSource(string externalSourceId);
+        GroupExternalContentSourcesResponse ListExternalContentSources(string after = null, string before = null, int? size = null);
+        IndividualExternalContentSourceResponse CreateExternalContentSource(ExternalContentSourceRequest externalContentSource);
+
+        IndividualExternalContentSourceResponse UpdateExternalContentSource(string externalSourceId, ExternalContentSource externalContentSource);
+        bool? DeleteExternalContentSource(string externalSourceId);
+#endif
+#if ASYNC   
+        Task<IndividualExternalContentSourceResponse> ShowExternalContentSourceAsync(string externalSourceId);
+        Task<GroupExternalContentSourcesResponse> ListExternalContentSourcesAsync(string after = null, string before = null, int? size = null);     
+        Task<IndividualExternalContentSourceResponse> CreateExternalContentSourceAync(ExternalContentSourceRequest externalContentSource);
+        Task<IndividualExternalContentSourceResponse> UpdateExternalContentSourceAsync(string externalSourceId, ExternalContentSource externalContentSource);
+        Task<bool?> DeleteExternalContentSourceAsync(string externalSourceId);
+#endif
+
+    }
+
+    public class ExternalContentSources: Core, IExternalContentSources
+    {
+        private readonly string urlPrefix = "guide/external_content";
+
+        public ExternalContentSources(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
+        {
+            if (!locale.IsNullOrWhiteSpace())
+            {
+                urlPrefix = $"{urlPrefix}";//locale isn't used in the federated search URL
+            }
+        }
+#if SYNC
+        public IndividualExternalContentSourceResponse ShowExternalContentSource(string externalSourceId)
+        {
+            var resourceUrl = $"{urlPrefix}/sources/{externalSourceId}";
+
+            return GenericGet<IndividualExternalContentSourceResponse>(resourceUrl);
+        }
+        public GroupExternalContentSourcesResponse ListExternalContentSources(string after=null, string before=null, int? size=null)
+        {
+            var resourceUrl = $"{urlPrefix}/sources?" + BuildExternalContentQueryString(after,before,size);
+
+            return GenericGet<GroupExternalContentSourcesResponse>(resourceUrl);
+
+        }
+
+        public IndividualExternalContentSourceResponse CreateExternalContentSource(ExternalContentSourceRequest externalContentSource)
+        {
+            var resourceUrl = $"{urlPrefix}/sources";
+
+            return GenericPost<IndividualExternalContentSourceResponse>(resourceUrl,externalContentSource);
+        }
+
+        public IndividualExternalContentSourceResponse UpdateExternalContentSource(string externalSourceId, ExternalContentSource externalContentSource)
+        {
+            var resourceUrl = $"{urlPrefix}/sources/{externalSourceId}";
+            return GenericPut<IndividualExternalContentSourceResponse>(resourceUrl, externalContentSource);
+        }
+        public bool? DeleteExternalContentSource(string externalSourceId)
+        {
+            var resourceUrl = $"{urlPrefix}/sources/{externalSourceId}";
+            return GenericDelete<bool?>(resourceUrl);
+        }
+#endif
+
+#if ASYNC
+        public async Task<IndividualExternalContentSourceResponse> ShowExternalContentSourceAsync(string externalSourceId)
+        {
+            var resourceUrl = $"{urlPrefix}/sources/{externalSourceId}";
+
+            return await GenericGetAsync<IndividualExternalContentSourceResponse>(resourceUrl);
+        }
+
+        public async Task<GroupExternalContentSourcesResponse> ListExternalContentSourcesAsync(string after=null, string before=null, int? size=null)
+        {
+            var resourceUrl = $"{urlPrefix}/sources?" + BuildExternalContentQueryString(after,before,size);
+
+            return await GenericGetAsync<GroupExternalContentSourcesResponse>(resourceUrl);
+
+        }
+
+        public async Task<IndividualExternalContentSourceResponse> CreateExternalContentSourceAync(ExternalContentSourceRequest externalContentSource)
+        {
+            var resourceUrl = $"{urlPrefix}/sources";
+            
+            return await GenericPostAsync<IndividualExternalContentSourceResponse>(resourceUrl,externalContentSource);
+        }
+
+        public async Task<IndividualExternalContentSourceResponse> UpdateExternalContentSourceAsync(string externalSourceId, ExternalContentSource externalContentSource)
+        {
+            var resourceUrl = $"{urlPrefix}/sources/{externalSourceId}";
+            return await GenericPutAsync<IndividualExternalContentSourceResponse>(resourceUrl, externalContentSource);
+        }
+        public async Task<bool?> DeleteExternalContentSourceAsync(string externalSourceId)
+        {
+            var resourceUrl = $"{urlPrefix}/sources/{externalSourceId}";
+            return await GenericDeleteAsync<bool?>(resourceUrl);
+        }
+#endif
+        private string BuildExternalContentQueryString(string after=null, string before=null, int? size=null)
+        {
+            var queryParams = new Dictionary<string, string>()
+            {
+                {"after",after},
+                {"before",before},
+                {"size",size.ToString()}
+            };
+            return queryParams.GetQueryString();
+        }
+    }
+}

--- a/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentType.cs
+++ b/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentType.cs
@@ -20,7 +20,6 @@ namespace ZendeskApi_v2.Requests.FederatedSearch
         IndividualExternalContentTypeResponse ShowExternalContentType(string externalSourceId);
         GroupExternalContentTypesResponse ListExternalContentTypes(string after = null, string before = null, int? size = null);
         IndividualExternalContentTypeResponse CreateExternalContentType(ExternalContentTypeRequest externalContentRecord);
-
         IndividualExternalContentTypeResponse UpdateExternalContentType(string externalSourceId, ExternalContentType externalContentRecord);
         bool? DeleteExternalContentType(string externalSourceId);
 #endif
@@ -50,21 +49,17 @@ namespace ZendeskApi_v2.Requests.FederatedSearch
         public IndividualExternalContentTypeResponse ShowExternalContentType(string externalTypeId)
         {
             var resourceUrl = $"{urlPrefix}/types/{externalTypeId}";
-
             return GenericGet<IndividualExternalContentTypeResponse>(resourceUrl);
         }
         public GroupExternalContentTypesResponse ListExternalContentTypes(string after=null, string before=null, int? size=null)
         {
             var resourceUrl = $"{urlPrefix}/types?" + BuildExternalContentQueryString(after,before,size);
-
             return GenericGet<GroupExternalContentTypesResponse>(resourceUrl);
-
         }
 
         public IndividualExternalContentTypeResponse CreateExternalContentType(ExternalContentTypeRequest externalContentType)
         {
             var resourceUrl = $"{urlPrefix}/types";
-
             return GenericPost<IndividualExternalContentTypeResponse>(resourceUrl,externalContentType);
         }
 
@@ -84,22 +79,18 @@ namespace ZendeskApi_v2.Requests.FederatedSearch
         public async Task<IndividualExternalContentTypeResponse> ShowExternalContentTypeAsync(string externalTypeId)
         {
             var resourceUrl = $"{urlPrefix}/types/{externalTypeId}";
-
             return await GenericGetAsync<IndividualExternalContentTypeResponse>(resourceUrl);
         }
 
         public async Task<GroupExternalContentTypesResponse> ListExternalContentTypesAsync(string after=null, string before=null, int? size=null)
         {
             var resourceUrl = $"{urlPrefix}/types?" + BuildExternalContentQueryString(after,before,size);
-
             return await GenericGetAsync<GroupExternalContentTypesResponse>(resourceUrl);
-
         }
 
         public async Task<IndividualExternalContentTypeResponse> CreateExternalContentTypeAsync(ExternalContentTypeRequest externalContentType)
         {
             var resourceUrl = $"{urlPrefix}/types";
-            
             return await GenericPostAsync<IndividualExternalContentTypeResponse>(resourceUrl,externalContentType);
         }
 

--- a/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentType.cs
+++ b/src/ZendeskApi_v2/Requests/FederatedSearch/ExternalContentType.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+#if ASYNC
+
+using System.Threading.Tasks;
+
+#endif
+
+using ZendeskApi_v2.Extensions;
+using ZendeskApi_v2.Models.FederatedSearch;
+
+namespace ZendeskApi_v2.Requests.FederatedSearch
+{
+    public interface IExternalContentTypes : ICore
+    {
+#if SYNC
+        IndividualExternalContentTypeResponse ShowExternalContentType(string externalSourceId);
+        GroupExternalContentTypesResponse ListExternalContentTypes(string after = null, string before = null, int? size = null);
+        IndividualExternalContentTypeResponse CreateExternalContentType(ExternalContentTypeRequest externalContentRecord);
+
+        IndividualExternalContentTypeResponse UpdateExternalContentType(string externalSourceId, ExternalContentType externalContentRecord);
+        bool? DeleteExternalContentType(string externalSourceId);
+#endif
+#if ASYNC   
+        Task<IndividualExternalContentTypeResponse> ShowExternalContentTypeAsync(string externalSourceId);
+        Task<GroupExternalContentTypesResponse> ListExternalContentTypesAsync(string after = null, string before = null, int? size = null);     
+        Task<IndividualExternalContentTypeResponse> CreateExternalContentTypeAsync(ExternalContentTypeRequest externalContentRecord);
+        Task<IndividualExternalContentTypeResponse> UpdateExternalContentTypeAsync(string externalSourceId, ExternalContentType externalContentRecord);
+        Task<bool?> DeleteExternalContentTypeAsync(string externalSourceId);
+#endif
+
+    }
+
+    public class ExternalContentTypes: Core, IExternalContentTypes
+    {
+        private readonly string urlPrefix = "guide/external_content";
+
+        public ExternalContentTypes(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
+        {
+            if (!locale.IsNullOrWhiteSpace())
+            {
+                urlPrefix = $"{urlPrefix}";
+            }
+        }
+#if SYNC
+        public IndividualExternalContentTypeResponse ShowExternalContentType(string externalTypeId)
+        {
+            var resourceUrl = $"{urlPrefix}/types/{externalTypeId}";
+
+            return GenericGet<IndividualExternalContentTypeResponse>(resourceUrl);
+        }
+        public GroupExternalContentTypesResponse ListExternalContentTypes(string after=null, string before=null, int? size=null)
+        {
+            var resourceUrl = $"{urlPrefix}/types?" + BuildExternalContentQueryString(after,before,size);
+
+            return GenericGet<GroupExternalContentTypesResponse>(resourceUrl);
+
+        }
+
+        public IndividualExternalContentTypeResponse CreateExternalContentType(ExternalContentTypeRequest externalContentType)
+        {
+            var resourceUrl = $"{urlPrefix}/types";
+
+            return GenericPost<IndividualExternalContentTypeResponse>(resourceUrl,externalContentType);
+        }
+
+        public IndividualExternalContentTypeResponse UpdateExternalContentType(string externalRecordId, ExternalContentType externalContentRecord)
+        {
+            var resourceUrl = $"{urlPrefix}/types/{externalRecordId}";
+            return GenericPut<IndividualExternalContentTypeResponse>(resourceUrl, externalContentRecord);
+        }
+        public bool? DeleteExternalContentType(string externalTypeId)
+        {
+            var resourceUrl = $"{urlPrefix}/types/{externalTypeId}";
+            return GenericDelete<bool?>(resourceUrl);
+        }
+#endif
+
+#if ASYNC
+        public async Task<IndividualExternalContentTypeResponse> ShowExternalContentTypeAsync(string externalTypeId)
+        {
+            var resourceUrl = $"{urlPrefix}/types/{externalTypeId}";
+
+            return await GenericGetAsync<IndividualExternalContentTypeResponse>(resourceUrl);
+        }
+
+        public async Task<GroupExternalContentTypesResponse> ListExternalContentTypesAsync(string after=null, string before=null, int? size=null)
+        {
+            var resourceUrl = $"{urlPrefix}/types?" + BuildExternalContentQueryString(after,before,size);
+
+            return await GenericGetAsync<GroupExternalContentTypesResponse>(resourceUrl);
+
+        }
+
+        public async Task<IndividualExternalContentTypeResponse> CreateExternalContentTypeAsync(ExternalContentTypeRequest externalContentType)
+        {
+            var resourceUrl = $"{urlPrefix}/types";
+            
+            return await GenericPostAsync<IndividualExternalContentTypeResponse>(resourceUrl,externalContentType);
+        }
+
+        public async Task<IndividualExternalContentTypeResponse> UpdateExternalContentTypeAsync(string externalTypeId, ExternalContentType externalContentType)
+        {
+            var resourceUrl = $"{urlPrefix}/types/{externalTypeId}";
+            return await GenericPutAsync<IndividualExternalContentTypeResponse>(resourceUrl, externalContentType);
+        }
+        public async Task<bool?> DeleteExternalContentTypeAsync(string externalTypeId)
+        {
+            var resourceUrl = $"{urlPrefix}/types/{externalTypeId}";
+            return await GenericDeleteAsync<bool?>(resourceUrl);
+        }
+#endif
+        private string BuildExternalContentQueryString(string after=null, string before=null, int? size=null)
+        {
+            var queryParams = new Dictionary<string, string>()
+            {
+                {"after",after},
+                {"before",before},
+                {"size",size.ToString()}
+            };
+            return queryParams.GetQueryString();
+        }
+    }
+}

--- a/src/ZendeskApi_v2/ZendeskApi.cs
+++ b/src/ZendeskApi_v2/ZendeskApi.cs
@@ -2,7 +2,9 @@
 using ZendeskApi_v2.Requests;
 using System.Net;
 using ZendeskApi_v2.HelpCenter;
+using ZendeskApi_v2.Requests.FederatedSearch;
 using System.Collections.Generic;
+using ZendeskApi_v2.FederatedSearch;
 
 #if Net35
 using System.Web;
@@ -36,6 +38,7 @@ namespace ZendeskApi_v2
         ISchedules Schedules { get; }
         ITargets Targets { get; }
         IAutomations Automations { get; }
+        IFederatedSearchApi FederatedSearch{get;}
 
         string ZendeskUrl { get; }
     }
@@ -65,6 +68,7 @@ namespace ZendeskApi_v2
         public ISchedules Schedules { get; set; }
         public ITargets Targets { get; set; }
         public IAutomations Automations { get; set; }
+        public IFederatedSearchApi FederatedSearch{get;set;}
 
         public string ZendeskUrl { get; set; }
 
@@ -167,6 +171,7 @@ namespace ZendeskApi_v2
             Schedules = new Schedules(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
             Targets = new Targets(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
             Automations = new Automations(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            FederatedSearch = new FederatedSearchApi(formattedUrl, user, password, apiToken, locale, p_OAuthToken, customHeaders);
 
             ZendeskUrl = formattedUrl;
         }

--- a/src/ZendeskApi_v2/ZendeskApi_v2.csproj
+++ b/src/ZendeskApi_v2/ZendeskApi_v2.csproj
@@ -55,7 +55,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\tools\icon\lotus.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\tools\icon\lotus.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   
   

--- a/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentRecordsTests.cs
+++ b/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentRecordsTests.cs
@@ -1,0 +1,165 @@
+using NuGet.Frameworks;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using ZendeskApi_v2.Requests.FederatedSearch;
+using ZendeskApi_v2.Models.FederatedSearch;
+using ZendeskApi_v2.Tests.Base;
+
+namespace ZendeskApi_v2.Tests.FederatedSearch;
+
+[TestFixture]
+[Category("FederatedSearch")]
+[Parallelizable(ParallelScope.None)]
+public class ExternalContentRecordsTest : TestBase
+{
+
+    private string _externalContentId = String.Empty;
+    private string _externalContentIdAsync = String.Empty;
+    private ExternalContentType _externalContentType = null;
+    private ExternalContentSource _externalContentSource = null;
+
+    [OneTimeSetUp]
+    public void ExternalContentSetUp() {
+
+        var _externalContentTypePayload = new ExternalContentTypeRequest
+        {
+            Type = new ExternalContentType
+            {
+                Name = "Test External Type"
+            }
+        };
+        var typeRes = Api.FederatedSearch.ExternalContentTypes.CreateExternalContentType(_externalContentTypePayload);
+        _externalContentType = typeRes?.Type;
+
+        
+
+        var _externalContentSourcePayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentSourceRequest
+        {
+            Source = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentSource
+            {
+                Name = "Test Source"
+            }
+        };
+
+        var sourceRes = Api.FederatedSearch.ExternalContentSources.CreateExternalContentSource(_externalContentSourcePayload);
+        _externalContentSource = sourceRes?.Source;
+
+    }
+
+    [OneTimeTearDown]
+    public async Task ExternalContentCleanUp() 
+    {
+
+        await Api.FederatedSearch.ExternalContentSources.DeleteExternalContentSourceAsync(_externalContentSource.Id);
+        await Api.FederatedSearch.ExternalContentTypes.DeleteExternalContentTypeAsync(_externalContentType.Id);
+
+    }
+
+
+    [Test, Order(1)]
+    public void CanCreateAndUpdateExternalContentRecord()
+    {
+
+        var createRecordPayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentRecordRequest { 
+            Record = new ZendeskApi_v2.Models.FederatedSearch.CreateUpdateExternalContentRecord 
+            {
+                TypeId = _externalContentType.Id,
+                SourceId = _externalContentSource.Id,
+                Title = "Test External Content Record",
+                Body = "Body of a test external content record",
+                ExternalId = "ANYID",
+                Locale = "en-us",
+                Url = "https://example.com/test/external/content",
+                UserSegmentId = "-1"
+            } 
+        };
+
+        var res = Api.FederatedSearch.ExternalContentRecords.CreateExternalContentRecord(createRecordPayload);
+
+        Assert.That(res.Record,Is.Not.Null);
+        _externalContentId = res.Record.Id;
+
+        createRecordPayload.Record.Body = "Updated Body";
+        var updateRes = Api.FederatedSearch.ExternalContentRecords.UpdateExternalContentRecord(res.Record.Id, createRecordPayload);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(updateRes.Record.Body, Is.EqualTo(createRecordPayload.Record.Body));
+        });
+    }
+
+    [Test, Order(2)]
+    public async Task CanCreateAndUpdateExternalContentRecordAsync()
+    {
+
+        var createRecordPayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentRecordRequest
+        {
+            Record = new ZendeskApi_v2.Models.FederatedSearch.CreateUpdateExternalContentRecord
+            {
+                TypeId = _externalContentType.Id,
+                SourceId = _externalContentSource.Id,
+                Title = "Test External Content Record",
+                Body = "Body of a test external content record",
+                ExternalId = "ANYIDASYNC",
+                Locale = "en-us",
+                Url = "https://example.com/test/external/content",
+                UserSegmentId = "-1"
+            }
+        };
+
+        var res =  await Api.FederatedSearch.ExternalContentRecords.CreateExternalContentRecordAsync(createRecordPayload);
+        Assert.That(res.Record,Is.Not.Null);
+        _externalContentIdAsync = res.Record.Id;
+
+        createRecordPayload.Record.Body = "Updated Body";
+        var updateRes = await Api.FederatedSearch.ExternalContentRecords.UpdateExternalContentRecordAsync(res.Record.Id, createRecordPayload);
+
+        Assert.Multiple( () =>
+        {
+            Assert.That(updateRes.Record.Body, Is.EqualTo(createRecordPayload.Record.Body));
+        });
+
+    }
+    [Test, Order(3)]
+    public void CanGetSingleExternalContentRecord()
+    {
+        var res = Api.FederatedSearch.ExternalContentRecords.ShowExternalContentRecord(_externalContentId);
+        Assert.That(res.Record, Is.Not.Null);
+    }
+
+    [Test, Order(4)]
+    public async Task CanGetSingleExternalContentRecordAsync()
+    {
+        var res = await Api.FederatedSearch.ExternalContentRecords.ShowExternalContentRecordAsync(_externalContentId);
+        Assert.That(res.Record, Is.Not.Null);
+    }
+
+    [Test, Order(5)]
+    public void CanGetExternalContentRecords()
+    {
+        var res = Api.FederatedSearch.ExternalContentRecords.ListExternalContentRecords();
+        Assert.That(res.Records.Count, Is.GreaterThan(0));
+    }
+
+    [Test, Order(6)]
+    public async Task CanGetExternalContentRecordsAsync()
+    {
+        var res = await Api.FederatedSearch.ExternalContentRecords.ListExternalContentRecordsAsync();
+        Assert.That(res.Records.Count, Is.GreaterThan(0));
+    }
+    [Test, Order(7)]
+    public void CanDeleteExternalContentRecord() 
+    {
+        var res = Api.FederatedSearch.ExternalContentRecords.DeleteExternalContentRecord(_externalContentId);
+        Assert.IsTrue(res == null || res == true);
+    }
+
+    [Test, Order(8)]
+    public async Task CanDeleteExternalContentRecordAsync() 
+    {
+        var res = await Api.FederatedSearch.ExternalContentRecords.DeleteExternalContentRecordAsync(_externalContentIdAsync);
+        Assert.IsTrue(res == null || res == true);
+    }
+}

--- a/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentRecordsTests.cs
+++ b/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentRecordsTests.cs
@@ -21,8 +21,8 @@ public class ExternalContentRecordsTest : TestBase
     private ExternalContentSource _externalContentSource = null;
 
     [OneTimeSetUp]
-    public void ExternalContentSetUp() {
-
+    public void ExternalContentSetUp() 
+    {
         var _externalContentTypePayload = new ExternalContentTypeRequest
         {
             Type = new ExternalContentType
@@ -32,8 +32,6 @@ public class ExternalContentRecordsTest : TestBase
         };
         var typeRes = Api.FederatedSearch.ExternalContentTypes.CreateExternalContentType(_externalContentTypePayload);
         _externalContentType = typeRes?.Type;
-
-        
 
         var _externalContentSourcePayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentSourceRequest
         {
@@ -45,23 +43,16 @@ public class ExternalContentRecordsTest : TestBase
 
         var sourceRes = Api.FederatedSearch.ExternalContentSources.CreateExternalContentSource(_externalContentSourcePayload);
         _externalContentSource = sourceRes?.Source;
-
     }
-
     [OneTimeTearDown]
     public async Task ExternalContentCleanUp() 
     {
-
         await Api.FederatedSearch.ExternalContentSources.DeleteExternalContentSourceAsync(_externalContentSource.Id);
         await Api.FederatedSearch.ExternalContentTypes.DeleteExternalContentTypeAsync(_externalContentType.Id);
-
     }
-
-
     [Test, Order(1)]
     public void CanCreateAndUpdateExternalContentRecord()
     {
-
         var createRecordPayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentRecordRequest { 
             Record = new ZendeskApi_v2.Models.FederatedSearch.CreateUpdateExternalContentRecord 
             {
@@ -89,11 +80,9 @@ public class ExternalContentRecordsTest : TestBase
             Assert.That(updateRes.Record.Body, Is.EqualTo(createRecordPayload.Record.Body));
         });
     }
-
     [Test, Order(2)]
     public async Task CanCreateAndUpdateExternalContentRecordAsync()
     {
-
         var createRecordPayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentRecordRequest
         {
             Record = new ZendeskApi_v2.Models.FederatedSearch.CreateUpdateExternalContentRecord
@@ -120,7 +109,6 @@ public class ExternalContentRecordsTest : TestBase
         {
             Assert.That(updateRes.Record.Body, Is.EqualTo(createRecordPayload.Record.Body));
         });
-
     }
     [Test, Order(3)]
     public void CanGetSingleExternalContentRecord()
@@ -128,21 +116,18 @@ public class ExternalContentRecordsTest : TestBase
         var res = Api.FederatedSearch.ExternalContentRecords.ShowExternalContentRecord(_externalContentId);
         Assert.That(res.Record, Is.Not.Null);
     }
-
     [Test, Order(4)]
     public async Task CanGetSingleExternalContentRecordAsync()
     {
         var res = await Api.FederatedSearch.ExternalContentRecords.ShowExternalContentRecordAsync(_externalContentId);
         Assert.That(res.Record, Is.Not.Null);
     }
-
     [Test, Order(5)]
     public void CanGetExternalContentRecords()
     {
         var res = Api.FederatedSearch.ExternalContentRecords.ListExternalContentRecords();
         Assert.That(res.Records.Count, Is.GreaterThan(0));
     }
-
     [Test, Order(6)]
     public async Task CanGetExternalContentRecordsAsync()
     {

--- a/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentRecordsTests.cs
+++ b/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentRecordsTests.cs
@@ -14,15 +14,14 @@ namespace ZendeskApi_v2.Tests.FederatedSearch;
 [Parallelizable(ParallelScope.None)]
 public class ExternalContentRecordsTest : TestBase
 {
-
     private string _externalContentId = String.Empty;
     private string _externalContentIdAsync = String.Empty;
     private ExternalContentType _externalContentType = null;
     private ExternalContentSource _externalContentSource = null;
 
     [OneTimeSetUp]
-    public void ExternalContentSetUp() {
-
+    public void ExternalContentSetUp() 
+    {
         var _externalContentTypePayload = new ExternalContentTypeRequest
         {
             Type = new ExternalContentType
@@ -32,8 +31,6 @@ public class ExternalContentRecordsTest : TestBase
         };
         var typeRes = Api.FederatedSearch.ExternalContentTypes.CreateExternalContentType(_externalContentTypePayload);
         _externalContentType = typeRes?.Type;
-
-        
 
         var _externalContentSourcePayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentSourceRequest
         {
@@ -45,23 +42,16 @@ public class ExternalContentRecordsTest : TestBase
 
         var sourceRes = Api.FederatedSearch.ExternalContentSources.CreateExternalContentSource(_externalContentSourcePayload);
         _externalContentSource = sourceRes?.Source;
-
     }
-
     [OneTimeTearDown]
     public async Task ExternalContentCleanUp() 
     {
-
         await Api.FederatedSearch.ExternalContentSources.DeleteExternalContentSourceAsync(_externalContentSource.Id);
         await Api.FederatedSearch.ExternalContentTypes.DeleteExternalContentTypeAsync(_externalContentType.Id);
-
     }
-
-
     [Test, Order(1)]
     public void CanCreateAndUpdateExternalContentRecord()
     {
-
         var createRecordPayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentRecordRequest { 
             Record = new ZendeskApi_v2.Models.FederatedSearch.CreateUpdateExternalContentRecord 
             {
@@ -89,11 +79,9 @@ public class ExternalContentRecordsTest : TestBase
             Assert.That(updateRes.Record.Body, Is.EqualTo(createRecordPayload.Record.Body));
         });
     }
-
     [Test, Order(2)]
     public async Task CanCreateAndUpdateExternalContentRecordAsync()
     {
-
         var createRecordPayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentRecordRequest
         {
             Record = new ZendeskApi_v2.Models.FederatedSearch.CreateUpdateExternalContentRecord
@@ -120,7 +108,6 @@ public class ExternalContentRecordsTest : TestBase
         {
             Assert.That(updateRes.Record.Body, Is.EqualTo(createRecordPayload.Record.Body));
         });
-
     }
     [Test, Order(3)]
     public void CanGetSingleExternalContentRecord()
@@ -128,21 +115,18 @@ public class ExternalContentRecordsTest : TestBase
         var res = Api.FederatedSearch.ExternalContentRecords.ShowExternalContentRecord(_externalContentId);
         Assert.That(res.Record, Is.Not.Null);
     }
-
     [Test, Order(4)]
     public async Task CanGetSingleExternalContentRecordAsync()
     {
         var res = await Api.FederatedSearch.ExternalContentRecords.ShowExternalContentRecordAsync(_externalContentId);
         Assert.That(res.Record, Is.Not.Null);
     }
-
     [Test, Order(5)]
     public void CanGetExternalContentRecords()
     {
         var res = Api.FederatedSearch.ExternalContentRecords.ListExternalContentRecords();
         Assert.That(res.Records.Count, Is.GreaterThan(0));
     }
-
     [Test, Order(6)]
     public async Task CanGetExternalContentRecordsAsync()
     {

--- a/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentSourcesTests.cs
+++ b/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentSourcesTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.VisualBasic;
+using Newtonsoft.Json;
+using NuGet.Frameworks;
+using NUnit.Framework;
+using System;
+using System.Data.Common;
+using System.Linq;
+using System.Threading.Tasks;
+using ZendeskApi_v2.Requests.FederatedSearch;
+using ZendeskApi_v2.Tests.Base;
+
+namespace ZendeskApi_v2.Tests.FederatedSearch;
+
+[TestFixture]
+[Category("FederatedSearch")]
+[Parallelizable(ParallelScope.None)]
+public class ExternalContentSourcesTest : TestBase
+{
+
+    private string _externalSourceId = String.Empty;
+    private string _externalSourceIdAsync = String.Empty;
+    //need to create a source and use id as external source
+
+    [Test, Order(1)]
+    public void CanCreateExternalContentSource()
+    {
+        var testPayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentSourceRequest { 
+            Source = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentSource
+            {
+                Name = "Test Source"
+            }
+         };
+            
+        var res = Api.FederatedSearch.ExternalContentSources.CreateExternalContentSource(testPayload);
+        Assert.That(res.Source.Id, Is.Not.Null);
+        _externalSourceId = res.Source.Id;
+    }
+    [Test, Order(2)]
+    public async Task CanCreateExternalContentSourceAsync()
+    {
+        var testPayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentSourceRequest
+        {
+            Source = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentSource
+            {
+                Name = "Test Async"
+            }
+        };
+
+        var res = await Api.FederatedSearch.ExternalContentSources.CreateExternalContentSourceAync(testPayload);
+        Assert.That(res.Source.Id, Is.Not.Null);
+        _externalSourceIdAsync = res.Source.Id;
+    }
+
+    [Test, Order(3)]
+    public void CanGetSingleExternalContentSource()
+    {
+        var res = Api.FederatedSearch.ExternalContentSources.ShowExternalContentSource(_externalSourceId);
+        Assert.That(res.Source, Is.Not.Null);
+    }
+
+    [Test, Order(4)]
+    public async Task  CanGetSingleExternalContentSourceAsync()
+    {
+        var res = await Api.FederatedSearch.ExternalContentSources.ShowExternalContentSourceAsync(_externalSourceId);
+        Assert.That(res.Source, Is.Not.Null);
+    }
+
+    [Test, Order(5)]
+    public void CanGetExternalContentSources()
+    {
+        var res = Api.FederatedSearch.ExternalContentSources.ListExternalContentSources();
+        Assert.That(res.Sources.Count,Is.GreaterThan(0));
+    }
+
+    [Test, Order(6)]
+    public async Task CanGetExternalContentSourcesAsync()
+    {
+        var res = await Api.FederatedSearch.ExternalContentSources.ListExternalContentSourcesAsync();
+        Assert.That(res.Sources.Count, Is.GreaterThan(0));
+    }
+    [Test, Order(7)]
+    public void CanDeleteExternalContentSources()
+    {
+        var res = Api.FederatedSearch.ExternalContentSources.DeleteExternalContentSource(_externalSourceId);
+        Assert.IsTrue(res == null || res == true);
+    }
+    [Test, Order(8)]
+    public async Task CanDeleteExternalContentSourcesAsync()
+    {
+        var res = await Api.FederatedSearch.ExternalContentSources.DeleteExternalContentSourceAsync(_externalSourceIdAsync);
+        Assert.IsTrue(res == null || res == true);
+    }
+}

--- a/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentSourcesTests.cs
+++ b/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentSourcesTests.cs
@@ -16,7 +16,6 @@ namespace ZendeskApi_v2.Tests.FederatedSearch;
 [Parallelizable(ParallelScope.None)]
 public class ExternalContentSourcesTest : TestBase
 {
-
     private string _externalSourceId = String.Empty;
     private string _externalSourceIdAsync = String.Empty;
     //need to create a source and use id as external source
@@ -50,28 +49,24 @@ public class ExternalContentSourcesTest : TestBase
         Assert.That(res.Source.Id, Is.Not.Null);
         _externalSourceIdAsync = res.Source.Id;
     }
-
     [Test, Order(3)]
     public void CanGetSingleExternalContentSource()
     {
         var res = Api.FederatedSearch.ExternalContentSources.ShowExternalContentSource(_externalSourceId);
         Assert.That(res.Source, Is.Not.Null);
     }
-
     [Test, Order(4)]
     public async Task  CanGetSingleExternalContentSourceAsync()
     {
         var res = await Api.FederatedSearch.ExternalContentSources.ShowExternalContentSourceAsync(_externalSourceId);
         Assert.That(res.Source, Is.Not.Null);
     }
-
     [Test, Order(5)]
     public void CanGetExternalContentSources()
     {
         var res = Api.FederatedSearch.ExternalContentSources.ListExternalContentSources();
         Assert.That(res.Sources.Count,Is.GreaterThan(0));
     }
-
     [Test, Order(6)]
     public async Task CanGetExternalContentSourcesAsync()
     {

--- a/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentTypesTests.cs
+++ b/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentTypesTests.cs
@@ -14,7 +14,6 @@ namespace ZendeskApi_v2.Tests.FederatedSearch;
 [Parallelizable(ParallelScope.None)]
 public class ExternalContentTypesTest : TestBase
 {
-
     private string _externalTypeId = String.Empty;
     private string _externalTypeIdAsync = String.Empty;
 
@@ -37,7 +36,6 @@ public class ExternalContentTypesTest : TestBase
     [Test, Order(2)]
     public async Task CanCreateExternalContentTypeAsync()
     {
-
         var testPayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentTypeRequest
         {
             Type = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentType
@@ -91,6 +89,5 @@ public class ExternalContentTypesTest : TestBase
     {
         var res =await Api.FederatedSearch.ExternalContentTypes.DeleteExternalContentTypeAsync(_externalTypeIdAsync);
         Assert.IsTrue(res == null || res == true);
-
     }
 }

--- a/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentTypesTests.cs
+++ b/tests/ZendeskApi_v2.Tests/FederatedSearch/ExternalContentTypesTests.cs
@@ -1,0 +1,96 @@
+using Newtonsoft.Json;
+using NuGet.Frameworks;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using ZendeskApi_v2.Requests.FederatedSearch;
+using ZendeskApi_v2.Tests.Base;
+
+namespace ZendeskApi_v2.Tests.FederatedSearch;
+
+[TestFixture]
+[Category("FederatedSearch")]
+[Parallelizable(ParallelScope.None)]
+public class ExternalContentTypesTest : TestBase
+{
+
+    private string _externalTypeId = String.Empty;
+    private string _externalTypeIdAsync = String.Empty;
+
+    [Test, Order(1)]
+    public void CanCreateExternalContentType()
+    {
+        var testPayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentTypeRequest
+        {
+            Type = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentType
+            {
+                Name = "Test Type"
+            }
+        };
+
+        var res = Api.FederatedSearch.ExternalContentTypes.CreateExternalContentType(testPayload);
+        Assert.That(res.Type.Id, Is.Not.Null);
+        _externalTypeId = res.Type.Id;
+    }
+
+    [Test, Order(2)]
+    public async Task CanCreateExternalContentTypeAsync()
+    {
+
+        var testPayload = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentTypeRequest
+        {
+            Type = new ZendeskApi_v2.Models.FederatedSearch.ExternalContentType
+            {
+                Name = "Test Type Async"
+            }
+        };
+
+        var res = await Api.FederatedSearch.ExternalContentTypes.CreateExternalContentTypeAsync(testPayload);
+        Assert.That(res.Type.Id, Is.Not.Null);
+        _externalTypeIdAsync = res.Type.Id;
+    }
+
+    [Test, Order(3)]
+    public void CanGetSingleExternalContentType()
+    {
+        var res = Api.FederatedSearch.ExternalContentTypes.ShowExternalContentType(_externalTypeId);
+        Assert.That(res.Type, Is.Not.Null);
+    }
+
+    [Test, Order(4)]
+    public async Task CanGetSingleExternalContentTypeAsync()
+    {
+        var res = await Api.FederatedSearch.ExternalContentTypes.ShowExternalContentTypeAsync(_externalTypeId);
+        Assert.That(res.Type, Is.Not.Null);
+    }
+
+    [Test, Order(5)]
+    public void CanGetExternalContentTypes()
+    {
+        var res = Api.FederatedSearch.ExternalContentTypes.ListExternalContentTypes();
+        Assert.That(res.Types.Count, Is.GreaterThan(0));
+    }
+
+    [Test, Order(6)]
+    public async Task CanGetExternalContentTypesAsync()
+    {
+        var res = await Api.FederatedSearch.ExternalContentTypes.ListExternalContentTypesAsync();
+        Assert.That(res.Types.Count, Is.GreaterThan(0));
+    }
+
+    [Test, Order(7)]
+    public void CanDeleteExternalContentType()
+    {
+        var res = Api.FederatedSearch.ExternalContentTypes.DeleteExternalContentType(_externalTypeId);
+        Assert.IsTrue(res == null || res == true);
+    }
+
+    [Test, Order(8)]
+    public async Task CanDeleteExternalContentTypeAsync()
+    {
+        var res =await Api.FederatedSearch.ExternalContentTypes.DeleteExternalContentTypeAsync(_externalTypeIdAsync);
+        Assert.IsTrue(res == null || res == true);
+
+    }
+}


### PR DESCRIPTION
Hello.  I have added support for the [Federated Search/External Content ](https://developer.zendesk.com/api-reference/help_center/federated-search/introduction/)APIs in ZenDesk.  I have also included Sync/Async tests for all calls in the Federated Search namespace.  