### PR TITLE
Add Support for UserFields in ZendeskApi_v2

### DIFF
--- a/src/ZendeskApi_v2/Models/Constants/UserFieldTypes.cs
+++ b/src/ZendeskApi_v2/Models/Constants/UserFieldTypes.cs
@@ -1,0 +1,16 @@
+﻿namespace ZendeskApi_v2.Models.Constants
+{
+    public static class UserFieldTypes
+    {
+        public const string Text = "text";
+        public const string Textarea = "textarea";
+        public const string Checkbox = "checkbox";
+        public const string Date = "date";
+        public const string Integer = "integer";
+        public const string Decimal = "decimal";
+        public const string Regexp = "regexp";
+        public const string Dropdown = "dropdown";
+        public const string Lookup = "lookup";
+        public const string Multiselect = "multiselect";
+    }
+}

--- a/src/ZendeskApi_v2/Models/Shared/CustomFieldOption.cs
+++ b/src/ZendeskApi_v2/Models/Shared/CustomFieldOption.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace ZendeskApi_v2.Models.Shared
+{
+    public class CustomFieldOption
+    {
+        [JsonProperty("id")]
+        public long? Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("raw_name")]
+        public string RawName { get; set; }
+
+        [JsonProperty("value")]
+        public string Value { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/Users/GroupUserFieldResponse.cs
+++ b/src/ZendeskApi_v2/Models/Users/GroupUserFieldResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace ZendeskApi_v2.Models.Users
+{
+    public class GroupUserFieldResponse : GroupResponseBase
+    {
+        [JsonProperty("user_fields")]
+        public IList<UserField> UserFields { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/Users/IndividualUserFieldResponse.cs
+++ b/src/ZendeskApi_v2/Models/Users/IndividualUserFieldResponse.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace ZendeskApi_v2.Models.Users
+{
+    public class IndividualUserFieldResponse
+    {
+        [JsonProperty("user_field")]
+        public UserField UserField { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/Users/UserField.cs
+++ b/src/ZendeskApi_v2/Models/Users/UserField.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace ZendeskApi_v2.Models.Users
+{
+    public class UserFieldBase
+    { 
+        [JsonProperty("key")]
+        public string Key { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("raw_title")]
+        public string RawTitle { get; set; }
+
+        [JsonProperty("raw_description")]
+        public string RawDescription { get; set; }
+
+        [JsonProperty("position")]
+        public long? Position { get; set; }
+
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
+        [JsonProperty("system")]
+        public bool? System { get; set; }
+
+        [JsonProperty("regexp_for_validation")]
+        public string RegexpForValidation { get; set; }
+
+        [JsonProperty("custom_field_options")]
+        public IList<CustomFieldOptions> CustomFieldOptions { get; set; }
+
+        [JsonProperty("tag")]
+        public string Tag { get; set; }
+    }
+
+    public class UserField : UserFieldBase
+    {
+        [JsonProperty("id")]
+        public long? Id { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("created_at")]
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
+
+        [JsonProperty("updated_at")]
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTimeOffset? UpdatedAt { get; set; }
+    }
+
+    public class CustomFieldOptions : FieldOptions
+    {
+        [JsonProperty("id")]
+        public long? Id { get; set; }
+    }
+
+    public class FieldOptions
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("raw_name")]
+        public string RawName { get; set; }
+
+        [JsonProperty("value")]
+        public string Value { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/Users/UserField.cs
+++ b/src/ZendeskApi_v2/Models/Users/UserField.cs
@@ -2,16 +2,23 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using ZendeskApi_v2.Models.Shared;
 
 namespace ZendeskApi_v2.Models.Users
 {
-    public class UserFieldBase
-    { 
-        [JsonProperty("key")]
-        public string Key { get; set; }
+    public class UserField
+    {
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("id")]
+        public long? Id { get; set; }
 
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        [JsonProperty("key")]
+        public string Key { get; set; }
 
         [JsonProperty("title")]
         public string Title { get; set; }
@@ -37,21 +44,6 @@ namespace ZendeskApi_v2.Models.Users
         [JsonProperty("regexp_for_validation")]
         public string RegexpForValidation { get; set; }
 
-        [JsonProperty("custom_field_options")]
-        public IList<CustomFieldOptions> CustomFieldOptions { get; set; }
-
-        [JsonProperty("tag")]
-        public string Tag { get; set; }
-    }
-
-    public class UserField : UserFieldBase
-    {
-        [JsonProperty("id")]
-        public long? Id { get; set; }
-
-        [JsonProperty("url")]
-        public string Url { get; set; }
-
         [JsonProperty("created_at")]
         [JsonConverter(typeof(IsoDateTimeConverter))]
         public DateTimeOffset? CreatedAt { get; set; }
@@ -59,23 +51,11 @@ namespace ZendeskApi_v2.Models.Users
         [JsonProperty("updated_at")]
         [JsonConverter(typeof(IsoDateTimeConverter))]
         public DateTimeOffset? UpdatedAt { get; set; }
-    }
 
-    public class CustomFieldOptions : FieldOptions
-    {
-        [JsonProperty("id")]
-        public long? Id { get; set; }
-    }
+        [JsonProperty("tag")]
+        public string Tag { get; set; }
 
-    public class FieldOptions
-    {
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
-        [JsonProperty("raw_name")]
-        public string RawName { get; set; }
-
-        [JsonProperty("value")]
-        public string Value { get; set; }
+        [JsonProperty("custom_field_options")]
+        public IList<CustomFieldOption> CustomFieldOptions { get; set; }
     }
 }

--- a/src/ZendeskApi_v2/Requests/Users.cs
+++ b/src/ZendeskApi_v2/Requests/Users.cs
@@ -216,8 +216,8 @@ namespace ZendeskApi_v2.Requests
 
         Task<GroupUserFieldResponse> GetUserFieldsAsync();
         Task<IndividualUserFieldResponse> GetUserFieldByIdAsync(long id);
-        Task<IndividualUserFieldResponse> CreateUserFieldAsync(UserField ticketField, bool replaceNameSpacesWithUnderscore = true);
-        Task<IndividualUserFieldResponse> UpdateUserFieldAsync(UserField ticketField, bool replaceNameSpacesWithUnderscore = false);
+        Task<IndividualUserFieldResponse> CreateUserFieldAsync(UserField userField, bool replaceNameSpacesWithUnderscore = true);
+        Task<IndividualUserFieldResponse> UpdateUserFieldAsync(UserField userField, bool replaceNameSpacesWithUnderscore = false);
         Task<bool> DeleteUserFieldAsync(long id);
 #endif
     }

--- a/src/ZendeskApi_v2/Requests/Users.cs
+++ b/src/ZendeskApi_v2/Requests/Users.cs
@@ -116,6 +116,12 @@ namespace ZendeskApi_v2.Requests
         GroupUserExportResponse GetIncrementalUserExportNextPage(string nextPage);
 
         GroupSubscriptionsResponse GetSubscriptions(long userId, SubscriptionSideLoadOptions subscriptionSideLoadOptions = SubscriptionSideLoadOptions.None, int? perPage = null, int? page = null);
+
+        GroupUserFieldResponse GetUserFields();
+        IndividualUserFieldResponse GetUserFieldById(long id);
+        IndividualUserFieldResponse CreateUserField(UserField userField, bool replaceNameSpacesWithUnderscore = true);
+        IndividualUserFieldResponse UpdateUserField(UserField userField, bool replaceNameSpacesWithUnderscore = false);
+        bool DeleteUserField(long id);
 #endif
 
 #if ASYNC
@@ -207,6 +213,12 @@ namespace ZendeskApi_v2.Requests
         Task<GroupUserExportResponse> GetIncrementalUserExportNextPageAsync(string nextPage);
 
         Task<GroupSubscriptionsResponse> GetSubscriptionsAsync(long userId, SubscriptionSideLoadOptions subscriptionSideLoadOptions = SubscriptionSideLoadOptions.None, int? perPage = null, int? page = null);
+
+        Task<GroupUserFieldResponse> GetUserFieldsAsync();
+        Task<IndividualUserFieldResponse> GetUserFieldByIdAsync(long id);
+        Task<IndividualUserFieldResponse> CreateUserFieldAsync(UserField ticketField, bool replaceNameSpacesWithUnderscore = true);
+        Task<IndividualUserFieldResponse> UpdateUserFieldAsync(UserField ticketField, bool replaceNameSpacesWithUnderscore = false);
+        Task<bool> DeleteUserFieldAsync(long id);
 #endif
     }
 
@@ -214,7 +226,7 @@ namespace ZendeskApi_v2.Requests
     {
         private const string _incremental_export = "incremental/users.json?start_time=";
 
-        public Users(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+        public Users(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string, string> customHeaders)
             : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
@@ -478,6 +490,53 @@ namespace ZendeskApi_v2.Requests
         {
             return GenericPagedGet<GroupSubscriptionsResponse>($"help_center/users/{userId}/subscriptions.json".SubscriptionSideloadUri(subscriptionSideLoadOptions), perPage, page);
         }
+
+        public GroupUserFieldResponse GetUserFields()
+        {
+            return GenericGet<GroupUserFieldResponse>("user_fields.json");
+        }
+
+        public IndividualUserFieldResponse GetUserFieldById(long id)
+        {
+            return GenericGet<IndividualUserFieldResponse>($"user_fields/{id}.json");
+        }
+        public IndividualUserFieldResponse CreateUserField(UserField userField, bool replaceNameSpacesWithUnderscore = true)
+        {
+            if (userField.CustomFieldOptions != null)
+            {
+                foreach (var field in userField.CustomFieldOptions)
+                {
+                    if (replaceNameSpacesWithUnderscore)
+                    {
+                        field.Name = field.Name.Replace(' ', '_');
+                    }
+                    field.Value = field.Value.Replace(' ', '_');
+                }
+            }
+            return GenericPost<IndividualUserFieldResponse>($"user_fields.json", new { user_field = userField });
+
+        }
+
+        public IndividualUserFieldResponse UpdateUserField(UserField userField, bool replaceNameSpacesWithUnderscore = true)
+        {
+            if (userField.CustomFieldOptions != null)
+            {
+                foreach (var field in userField.CustomFieldOptions)
+                {
+                    if (replaceNameSpacesWithUnderscore)
+                    {
+                        field.Name = field.Name.Replace(' ', '_');
+                    }
+                    field.Value = field.Value.Replace(' ', '_');
+                }
+            }
+            return GenericPut<IndividualUserFieldResponse>($"user_fields/{userField.Id}.json", new { user_field = userField });
+        }
+
+        public bool DeleteUserField(long id)
+        {
+            return GenericDelete($"user_fields/{id}.json");
+        }
 #endif
 
 #if ASYNC
@@ -724,6 +783,53 @@ namespace ZendeskApi_v2.Requests
         public Task<GroupSubscriptionsResponse> GetSubscriptionsAsync(long userId, SubscriptionSideLoadOptions subscriptionSideLoadOptions = SubscriptionSideLoadOptions.None, int? perPage = null, int? page = null)
         {
             return GenericPagedGetAsync<GroupSubscriptionsResponse>($"help_center/users/{userId}/subscriptions.json".SubscriptionSideloadUri(subscriptionSideLoadOptions), perPage, page);
+        }
+
+        public async Task<GroupUserFieldResponse> GetUserFieldsAsync()
+        {
+            return await GenericGetAsync<GroupUserFieldResponse>("user_fields.json");
+        }
+
+        public async Task<IndividualUserFieldResponse> GetUserFieldByIdAsync(long id)
+        {
+            return await GenericGetAsync<IndividualUserFieldResponse>($"user_fields/{id}.json");
+        }
+        public async Task<IndividualUserFieldResponse> CreateUserFieldAsync(UserField userField, bool replaceNameSpacesWithUnderscore = true)
+        {
+            if (userField.CustomFieldOptions != null)
+            {
+                foreach (var field in userField.CustomFieldOptions)
+                {
+                    if (replaceNameSpacesWithUnderscore)
+                    {
+                        field.Name = field.Name.Replace(' ', '_');
+                    }
+                    field.Value = field.Value.Replace(' ', '_');
+                }
+            }
+            return await GenericPostAsync<IndividualUserFieldResponse>($"user_fields.json", new { user_field = userField });
+
+        }
+
+        public async Task<IndividualUserFieldResponse> UpdateUserFieldAsync(UserField userField, bool replaceNameSpacesWithUnderscore = true)
+        {
+            if (userField.CustomFieldOptions != null)
+            {
+                foreach (var field in userField.CustomFieldOptions)
+                {
+                    if (replaceNameSpacesWithUnderscore)
+                    {
+                        field.Name = field.Name.Replace(' ', '_');
+                    }
+                    field.Value = field.Value.Replace(' ', '_');
+                }
+            }
+            return await GenericPutAsync<IndividualUserFieldResponse>($"user_fields/{userField.Id}.json", new { user_field = userField });
+        }
+
+        public async Task<bool> DeleteUserFieldAsync(long id)
+        {
+            return await GenericDeleteAsync($"user_fields/{id}.json");
         }
 #endif
         private string GetResourceStringWithSideLoadOptionsParam(string resource, UserSideLoadOptions sideLoadOptions)

--- a/tests/ZendeskApi_v2.Tests/UserTests.cs
+++ b/tests/ZendeskApi_v2.Tests/UserTests.cs
@@ -945,11 +945,8 @@ public class UserTests : TestBase
 
     [TestCase(true, "test entryA", "test entryA newTitle", "test entryB", "test entryC", "test_entryA", "test_entryA_newTitle", "test_entryB", "test_entryC")]
     [TestCase(false, "test entryA", "test entryA newTitle", "test entryB", "test entryC", "test entryA", "test entryA newTitle", "test entryB", "test entryC")]
-    public void CanCreateUpdateOptionsAndDeleteDropdownUserField(bool replaceNameSpaceWithUnderscore, 
-                                                                 string name1, string name1_Update, string name2, string name3,
-                                                                 string expectedName1, string expectedName1_Update, string expectedName2, string expectedName3)
+    public void CanCreateUpdateOptionsAndDeleteDropdownUserField(bool replaceNameSpaceWithUnderscore, string name1, string name1_Update, string name2, string name3, string expectedName1, string expectedName1_Update, string expectedName2, string expectedName3)
     {
-         
         var option1 = "test_value_a";
         var option1_Update = "test value_a_newtag";
         var option2 = "test_value_b";

--- a/tests/ZendeskApi_v2.Tests/UserTests.cs
+++ b/tests/ZendeskApi_v2.Tests/UserTests.cs
@@ -919,14 +919,14 @@ public class UserTests : TestBase
             Description = "Test description",
             RawTitle = "My Dropdown",
             RawDescription = "Test description",
-            CustomFieldOptions = new List<CustomFieldOptions>
+            CustomFieldOptions = new List<CustomFieldOption>
             {
-                new CustomFieldOptions
+                new CustomFieldOption
                 {
                     Name = "test entryA",
                     Value = "Test2"
                 },
-                new CustomFieldOptions
+                new CustomFieldOption
                 {
                     Name = "test entryB",
                     Value = "test3"
@@ -945,8 +945,9 @@ public class UserTests : TestBase
 
     [TestCase(true, "test entryA", "test entryA newTitle", "test entryB", "test entryC", "test_entryA", "test_entryA_newTitle", "test_entryB", "test_entryC")]
     [TestCase(false, "test entryA", "test entryA newTitle", "test entryB", "test entryC", "test entryA", "test entryA newTitle", "test entryB", "test entryC")]
-    public void CanCreateUpdateOptionsAndDeleteDropdownUserField(bool replaceNameSpaceWithUnderscore, string name1, string name1_Update, string name2, string name3,
-        string expectedName1, string expectedName1_Update, string expectedName2, string expectedName3)
+    public void CanCreateUpdateOptionsAndDeleteDropdownUserField(bool replaceNameSpaceWithUnderscore, 
+                                                                 string name1, string name1_Update, string name2, string name3,
+                                                                 string expectedName1, string expectedName1_Update, string expectedName2, string expectedName3)
     {
          
         var option1 = "test_value_a";
@@ -961,16 +962,16 @@ public class UserTests : TestBase
             Description = "Test description",
             RawTitle = "My Dropdown",
             RawDescription = "Test description",
-            CustomFieldOptions = new List<CustomFieldOptions>()
+            CustomFieldOptions = new List<CustomFieldOption>()
         };
 
-        tField.CustomFieldOptions.Add(new CustomFieldOptions()
+        tField.CustomFieldOptions.Add(new CustomFieldOption()
         {
             Name = name1,
             Value = option1
         });
 
-        tField.CustomFieldOptions.Add(new CustomFieldOptions()
+        tField.CustomFieldOptions.Add(new CustomFieldOption()
         {
             Name = name2,
             Value = option2
@@ -995,18 +996,18 @@ public class UserTests : TestBase
         var tFieldU = new UserField()
         {
             Id = id,
-            CustomFieldOptions = new List<CustomFieldOptions>()
+            CustomFieldOptions = new List<CustomFieldOption>()
         };
 
         //update CustomFieldOption A
-        tFieldU.CustomFieldOptions.Add(new CustomFieldOptions()
+        tFieldU.CustomFieldOptions.Add(new CustomFieldOption()
         {
             Name = name1_Update,
             Value = option1_Update
         });
         //delete CustomFieldOption B
         //add CustomFieldOption C
-        tFieldU.CustomFieldOptions.Add(new CustomFieldOptions()
+        tFieldU.CustomFieldOptions.Add(new CustomFieldOption()
         {
             Name = name3,
             Value = option3
@@ -1041,16 +1042,16 @@ public class UserTests : TestBase
             Description = "Test description",
             RawTitle = "My Dropdown",
             RawDescription = "Test description",
-            CustomFieldOptions = new List<CustomFieldOptions>()
+            CustomFieldOptions = new List<CustomFieldOption>()
         };
 
-        tField.CustomFieldOptions.Add(new CustomFieldOptions()
+        tField.CustomFieldOptions.Add(new CustomFieldOption()
         {
             Name = "test entryA",
             Value = option1
         });
 
-        tField.CustomFieldOptions.Add(new CustomFieldOptions()
+        tField.CustomFieldOptions.Add(new CustomFieldOption()
         {
             Name = "test entryB",
             Value = option2
@@ -1073,18 +1074,18 @@ public class UserTests : TestBase
         var tFieldU = new UserField()
         {
             Id = id,
-            CustomFieldOptions = new List<CustomFieldOptions>()
+            CustomFieldOptions = new List<CustomFieldOption>()
         };
 
         //update CustomFieldOption A
-        tFieldU.CustomFieldOptions.Add(new CustomFieldOptions()
+        tFieldU.CustomFieldOptions.Add(new CustomFieldOption()
         {
             Name = "test entryA newTitle",
             Value = option1_Update
         });
         //delete CustomFieldOption B
         //add CustomFieldOption C
-        tFieldU.CustomFieldOptions.Add(new CustomFieldOptions()
+        tFieldU.CustomFieldOptions.Add(new CustomFieldOption()
         {
             Name = "test entryC",
             Value = option3
@@ -1168,10 +1169,10 @@ public class UserTests : TestBase
             Description = "Test description",
             RawTitle = "My Dropdown",
             RawDescription = "Test description",
-            CustomFieldOptions = new List<CustomFieldOptions>()
+            CustomFieldOptions = new List<CustomFieldOption>()
         };
 
-        tField.CustomFieldOptions.Add(new CustomFieldOptions()
+        tField.CustomFieldOptions.Add(new CustomFieldOption()
         {
             Name = name,
             Value = "test value"


### PR DESCRIPTION
Summary:
This pull request adds support for managing UserFields within the ZendeskApi_v2 package. It includes both synchronous and asynchronous methods for CRUD operations on UserFields. The implementation aligns with the existing structure for managing TicketFields, ensuring consistency and ease of use.

Changes Include:

API Methods: Implemented sync and async methods for UserFields operations.
Models: Added UserField, GroupUserFieldResponse, and IndividualUserFieldResponse models to represent UserFields and responses.
Constants: Introduced UserFieldTypes constants for standardized handling of field types.
Requests Update: Extended Users requests to support the new UserFields functionality.
Unit Tests: Updated UsersTests to cover the new UserField methods, including both sync and async operations.
Testing:

Added comprehensive unit tests to ensure proper functionality for all new methods.
Tests include validation of input and output for the UserFields operations, ensuring they work as expected.